### PR TITLE
Add UTC time to the boot-id view

### DIFF
--- a/app/dashboard/static/js/app/utils/date.js
+++ b/app/dashboard/static/js/app/utils/date.js
@@ -16,7 +16,40 @@ define(function() {
         month = month[1] ? month : '0' + month[0];
         day = day[1] ? day : '0' + day[0];
 
+
         return this.getUTCFullYear().toString() + '-' + month + '-' + day;
+    };
+
+    /*
+        Return a custom UTC full date string, including time, in ISO format.
+        The format returned is: YYYY-MM-DD HH:MM:SS
+    */
+    Date.prototype.toCustomISODateTime = function() {
+        var day,
+            month,
+            year,
+            hour,
+            minute,
+            second,
+            output;
+
+        day = this.getUTCDate().toString();
+        month = this.getUTCMonth() + 1;
+        year = this.getUTCFullYear().toString();
+        hour = this.getUTCHours().toString();
+        minute = this.getUTCMinutes().toString();
+        second = this.getUTCSeconds().toString();
+
+        month = month.toString();
+        month = month[1] ? month : '0' + month[0];
+        day = day[1] ? day : '0' + day[0];
+        hour = hour[1] ? hour : '0' + hour[0];
+        minute = minute[1] ? minute : '0' + minute[0];
+        second = second[1] ? second : '0' + second[0];
+        output = year + '-' + month + '-' + day
+                 + ' ' + hour + ':' + minute + ':' + second + ' UTC';
+
+        return output;
     };
 
     /*

--- a/app/dashboard/static/js/app/view-boots-id.2016.3.2.js
+++ b/app/dashboard/static/js/app/view-boots-id.2016.3.2.js
@@ -777,7 +777,7 @@ require([
         spanNode = document.createElement('time');
         spanNode.setAttribute('datetime', createdOn.toISOString());
         spanNode.appendChild(
-            document.createTextNode(createdOn.toCustomISODate()));
+            document.createTextNode(createdOn.toCustomISODateTime()));
         html.replaceContent(document.getElementById('dd-date'), spanNode);
 
         // Status.


### PR DESCRIPTION
Having UTC time in the single boot view is helpful when investigating when infrastructure problems started occuring.
Add a function to date.js to create it.

Someone should test this, I can't..
