### PR TITLE
Test view board-job-kernel fix multi lab view

### DIFF
--- a/app/dashboard/static/js/app/view-tests-board-job-kernel.2017.7.2.js
+++ b/app/dashboard/static/js/app/view-tests-board-job-kernel.2017.7.2.js
@@ -466,9 +466,9 @@ require([
     function getTests() {
         var data;
         var deferred;
-        var labTable;
 
         function getData(lab) {
+            var labTable;
             data.lab_name = lab;
 
             gLabTable.push(table({


### PR DESCRIPTION
Keep a reference of every labTable and do not override it.
That way the labTable can be updated with test info when
the callback happens.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>