### PR TITLE
Test pages add date range

### DIFF
--- a/app/dashboard/static/js/app/view-tests-all.2017.7.2.js
+++ b/app/dashboard/static/js/app/view-tests-all.2017.7.2.js
@@ -367,8 +367,16 @@ require([
 
     function getTests() {
         var deferred;
+        var reqData;
 
-        deferred = request.get('/_ajax/suite/distinct/board/', {});
+        reqData = {
+            sort: 'created_on',
+            sort_order: -1,
+            date_range: gDateRange,
+            limit: appconst.MAX_QUERY_LIMIT,
+        }
+
+        deferred = request.get('/_ajax/suite/distinct/board/', reqData);
         $.when(deferred)
             .fail(error.error, getTestsFail)
             .done(getTestsParse);

--- a/app/dashboard/templates/tests-board.html
+++ b/app/dashboard/templates/tests-board.html
@@ -2,19 +2,14 @@
 {%- block meta -%}
     <meta name="csrf-token" content="{{ csrf_token_r() }}">
 {%- endblock %}
+{%- block title %}{{ page_title|safe }}{%- endblock %}
 {%- block head %}
 {{ super() }}
 <link rel="stylesheet" type="text/css" href="/static/css/dataTables.bootstrap-1.10.11.css">
+<link href="/board/{{ board }}/feed.xml" rel="alternate" title="Recent Changes - Atom Feed" type="application/atom+xml">
 {%- endblock %}
-{%- block title %}{{ page_title|safe }}{%- endblock %}
 {%- block content %}
-<div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-        <div class="page-header">
-            <h3>{{ body_title|default('Latest Results')|safe }}</h3>
-        </div>
-    </div>
-</div>
+{%- include "date-range.html" %}
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3">
         <ul class="list-group">


### PR DESCRIPTION
Add a sort by date range for the test landing page.
Display date range sort information on the test/board page.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>