### PR TITLE
view-tests: Add 'skip' to test counts

### DIFF
--- a/app/dashboard/static/js/app/view-tests-board-job-kernel.2017.7.2.js
+++ b/app/dashboard/static/js/app/view-tests-board-job-kernel.2017.7.2.js
@@ -143,7 +143,7 @@ require([
                 operation_id: lab + '-cases-unknown-count-' + suiteId,
                 resource: 'count',
                 document: 'test_case',
-                query: queryStr + suiteId + '&status=OFFLINE&status=UNKNOWN'
+                query: queryStr + suiteId + '&status=OFFLINE&status=UNKNOWN&status=SKIP'
             });
         }
 

--- a/app/dashboard/static/js/app/view-tests-board-job.2017.7.2.js
+++ b/app/dashboard/static/js/app/view-tests-board-job.2017.7.2.js
@@ -189,7 +189,7 @@ require([
                 operation_id: 'cases-unknown-count-' + suiteCommit,
                 resource: 'count',
                 document: 'test_case',
-                query: queryStr + '&status=OFFLINE&status=UNKNOWN'
+                query: queryStr + '&status=OFFLINE&status=UNKNOWN&status=SKIP'
             });
         }
 

--- a/app/dashboard/static/js/app/view-tests-board.2017.7.2.js
+++ b/app/dashboard/static/js/app/view-tests-board.2017.7.2.js
@@ -199,7 +199,7 @@ require([
                 operation_id: 'cases-unknown-count-' + suiteTree,
                 resource: 'count',
                 document: 'test_case',
-                query: queryStr + '&status=OFFLINE&status=UNKNOWN'
+                query: queryStr + '&status=OFFLINE&status=UNKNOWN&status=SKIP'
             });
         }
 


### PR DESCRIPTION
Update the test views to query for skip tests and add them to the counts.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>