### PR TITLE
T7884 Look for boot id key _id rather than boot_id in bisection data

### DIFF
--- a/app/dashboard/static/js/app/utils/bisect.js
+++ b/app/dashboard/static/js/app/utils/bisect.js
@@ -1,18 +1,18 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -302,7 +302,12 @@ define([
         if (type === 'boot') {
             board = data.board;
             lab = data.lab_name;
-            docId = data.boot_id.$oid;
+            if (data.hasOwnProperty('boot_id')) {
+                // backwards compatibility
+                docId = data.boot_id.$oid;
+            } else {
+                docId = data._id.$oid;
+            }
         } else {
             docId = data._id.$oid;
         }


### PR DESCRIPTION
Now that the boot entry is used directly in the boot data, the _id
field from the boot entry is available rather than the created boot_id
one.  To be backwards compatible, use boot_id if it's there.
Otherwise, use the _id.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>