### PR TITLE
faq: point to the wiki in github instead wiki.kernelci.org

### DIFF
--- a/app/dashboard/templates/faq.html
+++ b/app/dashboard/templates/faq.html
@@ -80,7 +80,7 @@
                 <dt id="more-info">Where can I find more info about kernelci.org?</dt>
                 <dd>
                     For more information about kernelci.org and its architecture,
-                    please see <a href="http://wiki.kernelci.org/">wiki.kernelci.org</a>.
+                    please see <a href="https://github.com/kernelci/kernelci-doc/wiki">https://github.com/kernelci/kernelci-doc/wiki</a>.
                 </dd>
                 <dt id="the-code">Where can I find the code that kernelci.org is built on?</dt>
                 <dd>


### PR DESCRIPTION
The wiki in github has more up-to-date information than
wiki.kernelci.org - the last update was almost 2 years ago.
The GitHub Wiki also can be edited by anyone and is independant
from Linaro infrastructure.

Signed-off-by: Ana Guerrero Lopez <ana.guerrero@collabora.com>