### PR TITLE
Remove requests to the backend for the test sets

### DIFF
--- a/app/dashboard/__init__.py
+++ b/app/dashboard/__init__.py
@@ -177,9 +177,6 @@ def static_html_proxy(path):
     "/_ajax/test/suite",
     defaults={"api": "TEST_SUITE_API_ENDPOINT"}, methods=["GET"])
 @app.route(
-    "/_ajax/test/set",
-    defaults={"api": "TEST_SET_API_ENDPOINT"}, methods=["GET"])
-@app.route(
     "/_ajax/test/case",
     defaults={"api": "TEST_CASE_API_ENDPOINT"}, methods=["GET"])
 def ajax_get(api):

--- a/app/dashboard/default_settings.py
+++ b/app/dashboard/default_settings.py
@@ -52,7 +52,6 @@ STATISTICS_API_ENDPOINT = "/statistics"
 JOB_LOGS_ENPOINT = "/job/logs"
 JOB_ID_LOGS_ENPOINT = "/job/%s/logs"
 TEST_SUITE_API_ENDPOINT = "/test/suite"
-TEST_SET_API_ENDPOINT = "/test/set"
 TEST_CASE_API_ENDPOINT = "/test/case"
 
 # Default date range to show the results. The higher the value, the more

--- a/app/dashboard/templates/other-multiple-case-reports.html
+++ b/app/dashboard/templates/other-multiple-case-reports.html
@@ -1,11 +1,4 @@
 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-    <div id="sets-reports-div">
-        <div id="sets-reports-loading-div" class="pull-center">
-            <small>
-                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;searching for sets reports&hellip;
-            </small>
-        </div>
-    </div>
     <div id="cases-reports-div">
     {%- if is_mobile %}
         <div class="table-responsive" id="cases-reports-table-div">

--- a/app/dashboard/templates/tests-suite-id.html
+++ b/app/dashboard/templates/tests-suite-id.html
@@ -100,7 +100,7 @@
     <div class="page-header">
         <h3>Test Reports</h3>
     </div>
-    {%- include "other-multiple-set-reports.html" %}
+    {%- include "other-multiple-case-reports.html" %}
 </div>
 <input type="hidden" id="file-server" value='{{ config["FILE_SERVER_URL"] }}'>
 <input type="hidden" id="suite-id" value="{{ suite_id }}">


### PR DESCRIPTION
As the backend is being modified to allow more flexibility with test
groups and test cases, remove references to test sets from the front
end. None of the current test plans make use of test sets so the
displayed results will not be impacted.

For reference: https://github.com/kernelci/kernelci-backend/pull/74