### PR TITLE
Add compiler column to /build

### DIFF
--- a/app/dashboard/static/css/kci-base-2016.6.css
+++ b/app/dashboard/static/css/kci-base-2016.6.css
@@ -82,6 +82,7 @@ td.kernel-column-nf,
 .commit-column,
 .board-column,
 .defconfig-column,
+.compiler-column,
 .kernel-column {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/dashboard/static/js/app/view-builds-all.2017.5.js
+++ b/app/dashboard/static/js/app/view-builds-all.2017.5.js
@@ -46,6 +46,7 @@ require([
     gBuildSearchFields = [
         '_id',
         'arch',
+        'compiler_version_ext',
         'created_on',
         'defconfig_full',
         'git_branch',
@@ -197,6 +198,12 @@ require([
                     title: 'Arch.',
                     type: 'string',
                     className: 'arch-column'
+                },
+                {
+                    data: 'compiler_version_ext',
+                    title: 'Compiler',
+                    type: 'string',
+                    className: 'compiler-column'
                 },
                 {
                     data: 'created_on',


### PR DESCRIPTION
This will add 'compiler' column to https://kernelci.org/build/,
listing the build's compiler_version_ext attribute