### PR TITLE
Do not query the backend for test set counts and show NaN in table

### DIFF
--- a/app/dashboard/static/js/app/view-tests-board-job-kernel.2018.9.js
+++ b/app/dashboard/static/js/app/view-tests-board-job-kernel.2018.9.js
@@ -109,13 +109,6 @@ require([
             // TODO When sorting check if more than 1 result print conflict error
             batchOps.push({
                 method: 'GET',
-                operation_id: lab + '-sets-count-' + groupId,
-                resource: 'count',
-                document: 'test_set',
-                query: queryStr + groupId
-            });
-            batchOps.push({
-                method: 'GET',
                 operation_id: lab + '-cases-total-count-' + groupId,
                 resource: 'count',
                 document: 'test_case',
@@ -196,25 +189,7 @@ require([
 
         // Internal wrapper to provide the href.
         function _renderSetsCount(data, type) {
-            var rendered;
-
-            rendered = null;
-            if (type === 'display') {
-                rendered = ttest.countBadge({
-                    data: data,
-                    type: 'default',
-                    idStart: lab + '-sets-',
-                    extraClasses: ['sets-count-badge']
-                });
-            } else if (type === 'sort') {
-                if (gTableCount.hasOwnProperty(lab + '-sets-count-' + data)) {
-                    rendered = gTableCount[lab + '-sets-count-' + data];
-                } else {
-                    rendered = NaN;
-                }
-            }
-
-            return rendered;
+            return NaN;
         }
 
         // Internal wrapper for the filter.


### PR DESCRIPTION
The backend does not have the concept of test sets any more, only
nested groups.  While more changes would be necessary to show a tree
of test groups, start by disabling the requests to count the test sets
as they are not useful on the frontend and take some resources from
the backend server.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>