### PR TITLE
Replace /etc/linaro with /etc/kernelci

### DIFF
--- a/app/dashboard/__init__.py
+++ b/app/dashboard/__init__.py
@@ -51,7 +51,7 @@ __versionfull__ = __version__
 
 CSRF_TOKEN_H = "X-Csrftoken"
 
-DEFAULT_CONFIG_FILE = "/etc/linaro/kernelci-frontend.cfg"
+DEFAULT_CONFIG_FILE = "/etc/kernelci/kernelci-frontend.cfg"
 # Name of the environment variable that will be lookep up for app
 # configuration parameters.
 APP_ENVVAR = "FLASK_SETTINGS"

--- a/app/dashboard/default_settings.py
+++ b/app/dashboard/default_settings.py
@@ -23,10 +23,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 LOGGER_NAME = "kernelci-frontend"
-SESSION_COOKIE_NAME = "linarokernelci"
+SESSION_COOKIE_NAME = "kernelci.org"
 
 # Following keys should be defined in an external file and passed as an
-# environment variable called FLASK_SETTINGS, or in /etc/linaro in a file
+# environment variable called FLASK_SETTINGS, or in /etc/kernelci in a file
 # called kernelci-frontend.cfg.
 PREFERRED_URL_SCHEME = "http"
 # Add the trailing slash!


### PR DESCRIPTION
Rename the default configuration directory from /etc/linaro to
/etc/kernelci.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>