### PR TITLE
Fix the link to the project wiki

### DIFF
--- a/app/dashboard/templates/faq.html
+++ b/app/dashboard/templates/faq.html
@@ -80,7 +80,7 @@
                 <dt id="more-info">Where can I find more info about kernelci.org?</dt>
                 <dd>
                     For more information about kernelci.org and its architecture,
-                    please see <a href="http://wiki.kernelci.org/">wiki.kernelci.org</a>.
+                    please see <a href="https://github.com/kernelci/kernelci-doc/wiki">the KernelCI wiki</a>.
                 </dd>
                 <dt id="the-code">Where can I find the code that kernelci.org is built on?</dt>
                 <dd>


### PR DESCRIPTION
This link is unreachable: http://wiki.kernelci.org/

Signed-off-by: Connor Kuehl <connor.kuehl@canonical.com>