### PR TITLE
Disable Compare view (Beta) due to backend errors

### DIFF
--- a/app/dashboard/templates/base.html
+++ b/app/dashboard/templates/base.html
@@ -79,12 +79,14 @@
                             <i class="fa fa-stethoscope"></i>&nbsp;Tests<small>&nbsp;<sup>&#946;</sup></small>
                         </a>
                     </li>
+                    <!-- Disabled as it needs fixing in kernrelci-backend
                     <li id="li-compare">
                         <a id="compare-l" href="/compare/"
                             title="Compare jobs, builds and boots (beta)">
                             <i class="fa fa-th-large"></i>&nbsp;Compare<small>&nbsp;<sup>&#946;</sup></small>
                         </a>
                     </li>
+                    -->
                     <li id="li-info">
                         <a id="info-l" href="/info/"
                             title="Want to know more about kernelci.org?">


### PR DESCRIPTION
The Compare view doesn't work any more as it hasn't been tested and
maintained for a while.  Since it's a Beta feature and nobody has
complained about it, we can disable it until this gets either fixed or
removed altogether in favour of a new web dashboard.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>