### PR TITLE
T18187 Show test results counts on jobs page rather than boots

### DIFF
--- a/app/dashboard/static/css/kci-base-2016.6.css
+++ b/app/dashboard/static/css/kci-base-2016.6.css
@@ -70,7 +70,7 @@ table {
     min-width: 30px;
     width: 30px;
 }
-.boot-count,
+.test-count,
 .build-count {
     min-width: 100px;
 }

--- a/app/dashboard/static/js/app/charts/passrate.js
+++ b/app/dashboard/static/js/app/charts/passrate.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -111,10 +111,10 @@ define([
         }
     }
 
-    passrate.bootpassrate = function(element, response) {
+    passrate.testpassrate = function(element, response) {
         prepareGraph(response, {
             element: element,
-            graphType: 'boot',
+            graphType: 'test',
             dataAttributes: ['job', 'kernel', 'pass', 'total'],
             clickFunction: k.toBootLinkClick
         });
@@ -131,4 +131,3 @@ define([
 
     return passrate;
 });
-

--- a/app/dashboard/static/js/app/tables/job.js
+++ b/app/dashboard/static/js/app/tables/job.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -34,9 +34,9 @@ define([
         default: 'Unknown status'
     };
 
-    gJobUtils.renderBootCount = function(settings) {
+    gJobUtils.renderTestCount = function(settings) {
         settings.extraClasses = ['extra-margin'];
-        settings.idStart = 'boot-';
+        settings.idStart = 'test-';
         return tcommon.countAll(settings);
     };
 

--- a/app/dashboard/static/js/app/view-jobs-all.2017.3.5.js
+++ b/app/dashboard/static/js/app/view-jobs-all.2017.3.5.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -195,19 +195,19 @@ require([
                 query: qHead
             });
 
-            // Get total boot reports count.
-            opId = 'boot-total-count-';
+            // Get total tests count.
+            opId = 'test-total-count-';
             opId += opIdTail;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
-                document: 'boot',
+                document: 'test_case',
                 query: qStr
             });
 
-            // Get successful boot reports count.
-            opId = 'boot-success-count-';
+            // Get successful tests count.
+            opId = 'test-success-count-';
             opId += opIdTail;
             qHead = 'status=PASS&';
             qHead += qStr;
@@ -215,33 +215,31 @@ require([
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
-                document: 'boot',
+                document: 'test_case',
                 query: qHead
             });
 
-            // Get failed boot reports count.
-            opId = 'boot-fail-count-';
+            // Get regressions count.
+            opId = 'test-fail-count-';
             opId += opIdTail;
-            qHead = 'status=FAIL&';
+            batchOps.push({
+                method: 'GET',
+                operation_id: opId,
+                resource: 'count',
+                document: 'test_regression',
+                query: qStr
+            });
+
+            // Get unknown test reports count.
+            opId = 'test-unknown-count-';
+            opId += opIdTail;
+            qHead = 'status=FAIL&status=SKIP&regression_id=null&';
             qHead += qStr;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
-                document: 'boot',
-                query: qHead
-            });
-
-            // Get unknown boot reports count.
-            opId = 'boot-unknown-count-';
-            opId += opIdTail;
-            qHead = 'status=OFFLINE&status=UNTRIED&status=UNKNOWN&';
-            qHead += qStr;
-            batchOps.push({
-                method: 'GET',
-                operation_id: opId,
-                resource: 'count',
-                document: 'boot',
+                document: 'test_case',
                 query: qHead
             });
         }
@@ -285,17 +283,17 @@ require([
         }
 
         /**
-         * Create the table column title for the boots count.
+         * Create the table column title for the test results count.
         **/
-        function _bootColumnTitle() {
+        function _testsColumnTitle() {
             var tooltipNode;
 
             tooltipNode = html.tooltip();
             tooltipNode.setAttribute(
                 'title',
-                'Total/Successful/Failed/Other boot reports for latest job');
+                'Total/Successful/Regressions/Other test results for latest job');
             tooltipNode.appendChild(
-                document.createTextNode('Latest Boot Status'));
+                document.createTextNode('Latest Test Results'));
 
             return tooltipNode.outerHTML;
         }
@@ -315,7 +313,7 @@ require([
         /**
          * Wrapper to provide the href.
         **/
-        function _renderBootCount(data, type, object) {
+        function _renderTestCount(data, type, object) {
             var href;
             var nodeId;
 
@@ -330,7 +328,7 @@ require([
             nodeId = data;
             nodeId += '-';
             nodeId += object.git_branch;
-            return jobt.renderBootCount({
+            return jobt.renderTestCount({
                 data: nodeId,
                 type: type,
                 href: href
@@ -398,12 +396,12 @@ require([
                 },
                 {
                     data: 'job',
-                    title: _bootColumnTitle(),
+                    title: _testsColumnTitle(),
                     type: 'string',
                     searchable: false,
                     orderable: false,
                     className: 'pull-center',
-                    render: _renderBootCount
+                    render: _renderTestCount
                 },
                 {
                     data: 'created_on',

--- a/app/dashboard/static/js/app/view-jobs-job-branch.2017.4.js
+++ b/app/dashboard/static/js/app/view-jobs-job-branch.2017.4.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -44,17 +44,17 @@ require([
 
     gNumberRange = 20;
 
-    function getBootStatsFail() {
+    function getTestStatsFail() {
         html.replaceContent(
-            document.getElementById('boot-pass-rate'),
-            html.errorDiv('Error loading boot data.'));
+            document.getElementById('test-pass-rate'),
+            html.errorDiv('Error loading test data.'));
     }
 
-    function getBootStatsDone(response) {
-        chart.bootpassrate('boot-pass-rate', response);
+    function getTestStatsDone(response) {
+        chart.testpassrate('test-pass-rate', response);
     }
 
-    function getBootStats(startDate, dateRange) {
+    function getTestStats(startDate, dateRange) {
         var data;
         var deferred;
 
@@ -68,10 +68,10 @@ require([
             field: ['status', 'kernel', 'created_on', 'job']
         };
 
-        deferred = r.get('/_ajax/boot', data);
+        deferred = r.get('/_ajax/test/case', data);
         $.when(deferred)
-            .fail(e.error, getBootStatsFail)
-            .done(getBootStatsDone);
+            .fail(e.error, getTestStatsFail)
+            .done(getTestStatsDone);
     }
 
     function getBuildsStatsFail() {
@@ -126,7 +126,7 @@ require([
                 getBuildsStats(firstDate.toCustomISODate(), lDateRange);
             }, 25);
             setTimeout(function() {
-                getBootStats(firstDate.toCustomISODate(), lDateRange);
+                getTestStats(firstDate.toCustomISODate(), lDateRange);
             }, 25);
         } else {
             html.replaceContent(
@@ -134,16 +134,16 @@ require([
                 html.errorDiv('No build data available.'));
 
             html.replaceContent(
-                document.getElementById('boot-pass-rate'),
-                html.errorDiv('No boot data available.'));
+                document.getElementById('test-pass-rate'),
+                html.errorDiv('No test data available.'));
         }
     }
 
-    function getBuildBootCountFail() {
+    function getBuildTestsCountFail() {
         html.replaceByClass('count-badge', '&infin;');
     }
 
-    function getBuildBootCountDone(response) {
+    function getBuildTestsCountDone(response) {
         var batchData;
 
         function parseBatchData(data) {
@@ -163,7 +163,7 @@ require([
             .search(gSearchFilter);
     }
 
-    function getBuildBootCount(response) {
+    function getBuildTestsCount(response) {
         var batchOps;
         var deferred;
         var kernel;
@@ -231,19 +231,19 @@ require([
                 query: qHead
             });
 
-            // Get total boot reports count.
-            opId = 'boot-total-count-';
+            // Get total tests count.
+            opId = 'test-total-count-';
             opId += kernel;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
-                document: 'boot',
+                document: 'test_case',
                 query: queryStr
             });
 
-            // Get successful boot reports count.
-            opId = 'boot-success-count-';
+            // Get successful tests count.
+            opId = 'test-success-count-';
             opId += kernel;
             qHead = 'status=PASS&';
             qHead += queryStr;
@@ -251,33 +251,31 @@ require([
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
-                document: 'boot',
+                document: 'test_case',
                 query: qHead
             });
 
-            // Get failed boot reports count.
-            opId = 'boot-fail-count-';
+            // Get regressions count.
+            opId = 'test-fail-count-';
             opId += kernel;
-            qHead = 'status=FAIL&';
+            batchOps.push({
+                method: 'GET',
+                operation_id: opId,
+                resource: 'count',
+                document: 'test_regression',
+                query: queryStr
+            });
+
+            // Get unknown test reports count.
+            opId = 'test-unknown-count-';
+            opId += kernel;
+            qHead = 'status=FAIL&status=SKIP&regression_id=null&';
             qHead += queryStr;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
-                document: 'boot',
-                query: qHead
-            });
-
-            // Get unknown boot reports count.
-            opId = 'boot-unknown-count-';
-            opId += kernel;
-            qHead = 'status=OFFLINE&status=UNTRIED&';
-            qHead += queryStr;
-            batchOps.push({
-                method: 'GET',
-                operation_id: opId,
-                resource: 'count',
-                document: 'boot',
+                document: 'test_case',
                 query: qHead
             });
         }
@@ -291,8 +289,8 @@ require([
                 '/_ajax/batch', JSON.stringify({batch: batchOps}));
 
             $.when(deferred)
-                .fail(e.error, getBuildBootCountFail)
-                .done(getBuildBootCountDone);
+                .fail(e.error, getBuildTestsCountFail)
+                .done(getBuildTestsCountDone);
         } else {
             html.replaceByClass('count-badge', '?');
         }
@@ -318,16 +316,16 @@ require([
         }
 
         /**
-         * Create the table column title for the boots count.
+         * Create the table column title for the tests count.
         **/
-        function _bootColumnTitle() {
+        function _testColumnTitle() {
             var tooltipNode;
 
             tooltipNode = html.tooltip();
             tooltipNode.setAttribute(
-                'title', 'Total/Successful/Failed/Other boot reports');
+                'title', 'Total/Successful/Regressions/Other test results');
             tooltipNode.appendChild(
-                document.createTextNode('Boot Status'));
+                document.createTextNode('Test Results'));
 
             return tooltipNode.outerHTML;
         }
@@ -359,7 +357,7 @@ require([
         /**
          * Wrapper to provide the href.
         **/
-        function _renderBootCount(data, type) {
+        function _renderTestCount(data, type) {
             var href = '/boot/all/job/';
             href += gJobName;
             href += '/branch/';
@@ -367,7 +365,7 @@ require([
             href += '/kernel/';
             href += data;
             href += '/';
-            return jobt.renderBootCount({data: data, type: type, href: href});
+            return jobt.renderTestCount({data: data, type: type, href: href});
         }
 
         function _renderBuildCount(data, type) {
@@ -418,10 +416,10 @@ require([
                 },
                 {
                     data: 'kernel',
-                    title: _bootColumnTitle(),
+                    title: _testColumnTitle(),
                     type: 'string',
-                    className: 'boot-count pull-center',
-                    render: _renderBootCount
+                    className: 'test-count pull-center',
+                    render: _renderTestCount
                 },
                 {
                     data: 'created_on',
@@ -486,8 +484,8 @@ require([
         $.when(deferred)
             .fail(
                 e.error,
-                getBuildsFailed, getBuildsStatsFail, getBootStatsFail)
-            .done(getTrendsData, getBuildsDone, getBuildBootCount);
+                getBuildsFailed, getBuildsStatsFail, getTestStatsFail)
+            .done(getTrendsData, getBuildsDone, getBuildTestsCount);
     }
 
     function getDetailsDone(response) {
@@ -562,10 +560,10 @@ require([
         });
 
         batchOps.push({
-            operation_id: 'boot-reports-count',
+            operation_id: 'test-results-count',
             method: 'GET',
             resource: 'count',
-            document: 'boot',
+            document: 'test_case',
             query: queryStr
         });
 

--- a/app/dashboard/static/js/worker/count-status-rate.js
+++ b/app/dashboard/static/js/worker/count-status-rate.js
@@ -1,9 +1,9 @@
 /* globals onmessage: true, postMessage: true */
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -19,7 +19,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 /**
- * Count the status of build and boot reports for a passrate graph.
+ * Count the status of build and test reports for a passrate graph.
  * Return a message with an object whose keys are the kernel value.
  * Each key holds an object with the follwing keys:
  * . job

--- a/app/dashboard/templates/jobs-job-branch.html
+++ b/app/dashboard/templates/jobs-job-branch.html
@@ -31,9 +31,9 @@
                 </span>
             </li>
             <li class="list-group-item">
-                Total boot reports
+                Total test results
                 <span class="badge">
-                <span id="boot-reports-count" class="count-list-badge">
+                <span id="test-results-count" class="count-list-badge">
                     <small><i class="fa fa-circle-o-notch fa-spin fa-fw"></i></small>
                 </span>
                 </span>
@@ -71,7 +71,7 @@
             <h4>Build Pass Rate</h4>
             <div id="build-pass-rate">
                 <div class="pull-center">
-                    <span id="boot-reports-count">
+                    <span id="build-count">
                         <small>
                             <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
                             &nbsp;calculating build pass rate&hellip;
@@ -81,13 +81,13 @@
             </div>
         </div>
         <div>
-            <h4>Boot Pass Rate</h4>
-            <div id="boot-pass-rate">
+            <h4>Test Pass Rate</h4>
+            <div id="test-pass-rate">
                 <div class="pull-center">
-                    <span id="boot-reports-count">
+                    <span id="test-count">
                         <small>
                             <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-                            &nbsp;calculating boot pass rate&hellip;
+                            &nbsp;calculating test pass rate&hellip;
                         </small>
                     </span>
                 </div>

--- a/app/dashboard/templates/jobs-job.html
+++ b/app/dashboard/templates/jobs-job.html
@@ -31,9 +31,9 @@
                 </span>
             </li>
             <li class="list-group-item">
-                Total boot reports
+                Total test results
                 <span class="badge">
-                <span id="boot-reports-count" class="count-list-badge">
+                <span id="test-results-count" class="count-list-badge">
                     <small><i class="fa fa-circle-o-notch fa-spin fa-fw"></i></small>
                 </span>
                 </span>
@@ -71,7 +71,7 @@
             <h4>Build Pass Rate</h4>
             <div id="build-pass-rate">
                 <div class="pull-center">
-                    <span id="boot-reports-count">
+                    <span id="build-count">
                         <small>
                             <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
                             &nbsp;calculating build pass rate&hellip;
@@ -81,13 +81,13 @@
             </div>
         </div>
         <div>
-            <h4>Boot Pass Rate</h4>
-            <div id="boot-pass-rate">
+            <h4>Test Pass Rate</h4>
+            <div id="test-pass-rate">
                 <div class="pull-center">
-                    <span id="boot-reports-count">
+                    <span id="test-count">
                         <small>
                             <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-                            &nbsp;calculating boot pass rate&hellip;
+                            &nbsp;calculating test pass rate&hellip;
                         </small>
                     </span>
                 </div>


### PR DESCRIPTION
Count the number of test results that passed, regressed or were
skipped rather than the number of boots and show it on the main jobs
page.

Depends on https://github.com/kernelci/kernelci-backend/pull/200