### PR TITLE
Revert buggy copyright header changes

### DIFF
--- a/app/dashboard/static/js/app/buttons/bisect.js
+++ b/app/dashboard/static/js/app/buttons/bisect.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/buttons/boot.js
+++ b/app/dashboard/static/js/app/buttons/boot.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/buttons/build.js
+++ b/app/dashboard/static/js/app/buttons/build.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/buttons/common.js
+++ b/app/dashboard/static/js/app/buttons/common.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/bar.js
+++ b/app/dashboard/static/js/app/charts/bar.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/base.js
+++ b/app/dashboard/static/js/app/charts/base.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/diffmatrix.js
+++ b/app/dashboard/static/js/app/charts/diffmatrix.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/matrix.js
+++ b/app/dashboard/static/js/app/charts/matrix.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/passpie.js
+++ b/app/dashboard/static/js/app/charts/passpie.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/passrate.js
+++ b/app/dashboard/static/js/app/charts/passrate.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/pie.js
+++ b/app/dashboard/static/js/app/charts/pie.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/rate.js
+++ b/app/dashboard/static/js/app/charts/rate.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/charts/statsbar.js
+++ b/app/dashboard/static/js/app/charts/statsbar.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/boot.js
+++ b/app/dashboard/static/js/app/compare/boot.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/bootdiff.js
+++ b/app/dashboard/static/js/app/compare/bootdiff.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/build.js
+++ b/app/dashboard/static/js/app/compare/build.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/builddiff.js
+++ b/app/dashboard/static/js/app/compare/builddiff.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/choose.js
+++ b/app/dashboard/static/js/app/compare/choose.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/common.js
+++ b/app/dashboard/static/js/app/compare/common.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/const.js
+++ b/app/dashboard/static/js/app/compare/const.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/diffcommon.js
+++ b/app/dashboard/static/js/app/compare/diffcommon.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/events.js
+++ b/app/dashboard/static/js/app/compare/events.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/factory.js
+++ b/app/dashboard/static/js/app/compare/factory.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/job.js
+++ b/app/dashboard/static/js/app/compare/job.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/jobdiff.js
+++ b/app/dashboard/static/js/app/compare/jobdiff.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/compare/utils.js
+++ b/app/dashboard/static/js/app/compare/utils.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/components/boot/common.js
+++ b/app/dashboard/static/js/app/components/boot/common.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/components/boot/regressions.js
+++ b/app/dashboard/static/js/app/components/boot/regressions.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/components/boot/unique.js
+++ b/app/dashboard/static/js/app/components/boot/unique.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/components/boot/view.js
+++ b/app/dashboard/static/js/app/components/boot/view.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/tables/boot.js
+++ b/app/dashboard/static/js/app/tables/boot.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/tables/build.js
+++ b/app/dashboard/static/js/app/tables/build.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/tables/common.js
+++ b/app/dashboard/static/js/app/tables/common.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/tables/job.js
+++ b/app/dashboard/static/js/app/tables/job.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/tables/soc.js
+++ b/app/dashboard/static/js/app/tables/soc.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/boot.js
+++ b/app/dashboard/static/js/app/utils/boot.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/compare.js
+++ b/app/dashboard/static/js/app/utils/compare.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/const.js
+++ b/app/dashboard/static/js/app/utils/const.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/date.js
+++ b/app/dashboard/static/js/app/utils/date.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/error.js
+++ b/app/dashboard/static/js/app/utils/error.js
@@ -1,11 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- * Author: Matt Hart <github@blacklabsystems.com>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/filter.js
+++ b/app/dashboard/static/js/app/utils/filter.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/format.js
+++ b/app/dashboard/static/js/app/utils/format.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/git-rules.js
+++ b/app/dashboard/static/js/app/utils/git-rules.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/html.js
+++ b/app/dashboard/static/js/app/utils/html.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/init.js
+++ b/app/dashboard/static/js/app/utils/init.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/request.js
+++ b/app/dashboard/static/js/app/utils/request.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/session.js
+++ b/app/dashboard/static/js/app/utils/session.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/storage.js
+++ b/app/dashboard/static/js/app/utils/storage.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/table.js
+++ b/app/dashboard/static/js/app/utils/table.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/utils/urls.js
+++ b/app/dashboard/static/js/app/utils/urls.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boot-compare.2017.4.js
+++ b/app/dashboard/static/js/app/view-boot-compare.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-all-jb.2017.3.4.js
+++ b/app/dashboard/static/js/app/view-boots-all-jb.2017.3.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-all-job-branch-kernel-defconfig.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-all-job-branch-kernel-defconfig.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-all-job-branch-kernel.2017.4.js
+++ b/app/dashboard/static/js/app/view-boots-all-job-branch-kernel.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-all-job-kernel-defconfig.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-all-job-kernel-defconfig.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-all-job.2017.3.4.js
+++ b/app/dashboard/static/js/app/view-boots-all-job.2017.3.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-all-lab.2017.3.5.js
+++ b/app/dashboard/static/js/app/view-boots-all-lab.2017.3.5.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-all.2017.5.js
+++ b/app/dashboard/static/js/app/view-boots-all.2017.5.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-board-jbkd.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-board-jbkd.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-board-job-kernel-defconfig.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-board-job-kernel-defconfig.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-board-job-kernel.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-board-job-kernel.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-board-job.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-board-job.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-board-lab.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-board-lab.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-board.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-board.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-id.2017.4.js
+++ b/app/dashboard/static/js/app/view-boots-id.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-job-kernel.2017.4.js
+++ b/app/dashboard/static/js/app/view-boots-job-kernel.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-boots-regressions.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-boots-regressions.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-build-compare.2017.4.js
+++ b/app/dashboard/static/js/app/view-build-compare.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-builds-id.2017.4.js
+++ b/app/dashboard/static/js/app/view-builds-id.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2017.7.1.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2017.7.1.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-builds-job-kernel-defconfig-logs.2017.4.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel-defconfig-logs.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-builds-job-kernel-defconfig.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel-defconfig.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-builds-job-kernel.2017.4.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-compare.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-compare.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-index.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-index.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-info-faq.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-info-faq.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-job-compare.2017.4.js
+++ b/app/dashboard/static/js/app/view-job-compare.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-jobs-all.2017.3.5.js
+++ b/app/dashboard/static/js/app/view-jobs-all.2017.3.5.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-jobs-job-branch.2017.4.js
+++ b/app/dashboard/static/js/app/view-jobs-job-branch.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-jobs-job.2017.4.js
+++ b/app/dashboard/static/js/app/view-jobs-job.2017.4.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-socs-all.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-socs-all.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2017.4.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2017.4.js
@@ -1,13 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
- * Copyright (C) Baylibre 2017
- * Author: lollivier <lollivier@baylibre.com>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-socs-soc-job.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-socs-soc.2018.2.js
+++ b/app/dashboard/static/js/app/view-socs-soc.2018.2.js
@@ -1,12 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- *
- * Copyright (C) Foundries.io 2018
- * Author: Milo Casagrande <milo@opensourcefoundries.com>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-sponsors.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-sponsors.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-stats.2017.3.3.js
+++ b/app/dashboard/static/js/app/view-stats.2017.3.3.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/app/view-tests-all.2018.9.js
+++ b/app/dashboard/static/js/app/view-tests-all.2018.9.js
@@ -1,12 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- *
- * Copyright (C) Collabora Limited 2018
- * Author: Ana Guerrero Lopez <ana.guerrero@collabora.com>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * Copyright (c) 2017 BayLibre, SAS.
  * Author: Loys Ollivier <lollivier@baylibre.com>
  * 

--- a/app/dashboard/static/js/kci-boot-compare.js
+++ b/app/dashboard/static/js/kci-boot-compare.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-all-jb.js
+++ b/app/dashboard/static/js/kci-boots-all-jb.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-all-jbk.js
+++ b/app/dashboard/static/js/kci-boots-all-jbk.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-all-job-branch-kernel-defconfig.js
+++ b/app/dashboard/static/js/kci-boots-all-job-branch-kernel-defconfig.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-all-job-kernel-defconfig.js
+++ b/app/dashboard/static/js/kci-boots-all-job-kernel-defconfig.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-all-job.js
+++ b/app/dashboard/static/js/kci-boots-all-job.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-all-lab.js
+++ b/app/dashboard/static/js/kci-boots-all-lab.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-all.js
+++ b/app/dashboard/static/js/kci-boots-all.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-board-jbkd.js
+++ b/app/dashboard/static/js/kci-boots-board-jbkd.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-board-job-kernel-defconfig.js
+++ b/app/dashboard/static/js/kci-boots-board-job-kernel-defconfig.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-board-job-kernel.js
+++ b/app/dashboard/static/js/kci-boots-board-job-kernel.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-board-job.js
+++ b/app/dashboard/static/js/kci-boots-board-job.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-board-lab.js
+++ b/app/dashboard/static/js/kci-boots-board-lab.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-board.js
+++ b/app/dashboard/static/js/kci-boots-board.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-id.js
+++ b/app/dashboard/static/js/kci-boots-id.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-boots-job-kernel.js
+++ b/app/dashboard/static/js/kci-boots-job-kernel.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-build-compare.js
+++ b/app/dashboard/static/js/kci-build-compare.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-builds-all.js
+++ b/app/dashboard/static/js/kci-builds-all.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-builds-id.js
+++ b/app/dashboard/static/js/kci-builds-id.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-builds-job-branch-kernel.js
+++ b/app/dashboard/static/js/kci-builds-job-branch-kernel.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-builds-job-kernel-defconfig-logs.js
+++ b/app/dashboard/static/js/kci-builds-job-kernel-defconfig-logs.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-builds-job-kernel-defconfig.js
+++ b/app/dashboard/static/js/kci-builds-job-kernel-defconfig.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-builds-job-kernel.js
+++ b/app/dashboard/static/js/kci-builds-job-kernel.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-compare.js
+++ b/app/dashboard/static/js/kci-compare.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-index.js
+++ b/app/dashboard/static/js/kci-index.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-info-faq.js
+++ b/app/dashboard/static/js/kci-info-faq.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-job-compare.js
+++ b/app/dashboard/static/js/kci-job-compare.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-jobs-all.js
+++ b/app/dashboard/static/js/kci-jobs-all.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-jobs-job-branch.js
+++ b/app/dashboard/static/js/kci-jobs-job-branch.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-jobs-job.js
+++ b/app/dashboard/static/js/kci-jobs-job.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-socs-all.js
+++ b/app/dashboard/static/js/kci-socs-all.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-socs-soc-job-kernel.js
+++ b/app/dashboard/static/js/kci-socs-soc-job-kernel.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-socs-soc-job.js
+++ b/app/dashboard/static/js/kci-socs-soc-job.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-socs-soc.js
+++ b/app/dashboard/static/js/kci-socs-soc.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-sponsors.js
+++ b/app/dashboard/static/js/kci-sponsors.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/kci-stats.js
+++ b/app/dashboard/static/js/kci-stats.js
@@ -1,10 +1,7 @@
 /*!
- * Copyright (C) Linaro Limited 2015,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/worker/boot-conflicts.js
+++ b/app/dashboard/static/js/worker/boot-conflicts.js
@@ -1,11 +1,8 @@
- * Copyright (C) Linaro Limited 2015,2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
 /* globals onmessage: true, postMessage: true */
 /*!
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/worker/boot-regressions.2016.11.js
+++ b/app/dashboard/static/js/worker/boot-regressions.2016.11.js
@@ -1,11 +1,8 @@
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
 /* globals onmessage: true, postMessage: true */
 /*!
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/worker/compiler-version.js
+++ b/app/dashboard/static/js/worker/compiler-version.js
@@ -1,11 +1,8 @@
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
 /* globals onmessage: true, postMessage: true */
 /*!
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/worker/count-status-rate.js
+++ b/app/dashboard/static/js/worker/count-status-rate.js
@@ -1,11 +1,8 @@
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
 /* globals onmessage: true, postMessage: true */
 /*!
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/static/js/worker/count-status.js
+++ b/app/dashboard/static/js/worker/count-status.js
@@ -1,11 +1,8 @@
- * Copyright (C) Linaro Limited 2016,2017,2019
- * Author: Matt Hart <matthew.hart@linaro.org>
- * Author: Milo Casagrande <milo.casagrande@linaro.org>
- *
 /* globals onmessage: true, postMessage: true */
 /*!
  * kernelci dashboard.
  * 
+ * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/app/dashboard/utils/backend.py
+++ b/app/dashboard/utils/backend.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2014,2015,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/utils/feed/__init__.py
+++ b/app/dashboard/utils/feed/__init__.py
@@ -1,7 +1,3 @@
-# Copyright (C) Linaro Limited 2015,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/utils/feed/boot.py
+++ b/app/dashboard/utils/feed/boot.py
@@ -1,7 +1,3 @@
-# Copyright (C) Linaro Limited 2015,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/utils/feed/job.py
+++ b/app/dashboard/utils/feed/job.py
@@ -1,7 +1,3 @@
-# Copyright (C) Linaro Limited 2015,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/utils/feed/soc.py
+++ b/app/dashboard/utils/feed/soc.py
@@ -1,7 +1,3 @@
-# Copyright (C) Linaro Limited 2015,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/utils/feeds.py
+++ b/app/dashboard/utils/feeds.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2015,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/views/boot.py
+++ b/app/dashboard/views/boot.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2014,2015,2016,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/views/build.py
+++ b/app/dashboard/views/build.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2014,2015,2016,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/views/compare.py
+++ b/app/dashboard/views/compare.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2015,2016,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/views/generic.py
+++ b/app/dashboard/views/generic.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2015,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/views/index.py
+++ b/app/dashboard/views/index.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2014,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/views/job.py
+++ b/app/dashboard/views/job.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2014,2015,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/views/soc.py
+++ b/app/dashboard/views/soc.py
@@ -1,7 +1,4 @@
-# Copyright (C) Linaro Limited 2015,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/server.py
+++ b/app/server.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
-# Copyright (C) Linaro Limited 2014,2017,2019
-# Author: Matt Hart <matthew.hart@linaro.org>
-# Author: Milo Casagrande <milo.casagrande@linaro.org>
 #
-#
+# Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)


### PR DESCRIPTION
Some Javascript files were broken during the automated copyright
header changes.  Also, some files didn't have any changes or new
contributors so there was no justification for updating the copyright
header.

Fixes: dd868bba833d ("Update Copyright lines to include years and authors of all commits")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>