### PR TITLE
T18074 test plans view

### DIFF
--- a/app/dashboard/static/js/app/charts/passpie.js
+++ b/app/dashboard/static/js/app/charts/passpie.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -119,6 +119,11 @@ define([
 
     passpie.bootpie = function(settings) {
         settings.text = 'total boots';
+        prepareGraph(settings);
+    };
+
+    passpie.testpie = function(settings) {
+        settings.text = 'test results';
         prepareGraph(settings);
     };
 

--- a/app/dashboard/static/js/app/tables/test.js
+++ b/app/dashboard/static/js/app/tables/test.js
@@ -134,5 +134,11 @@ define([
             .innerHTML ='&infin;';
     };
 
+    gTestTable.renderTestCount = function(settings) {
+        settings.extraClasses = ['extra-margin'];
+        settings.idStart = 'test-';
+        return tcommon.countAll(settings);
+    };
+
     return gTestTable;
 });

--- a/app/dashboard/static/js/app/view-jobs-all.2017.3.5.js
+++ b/app/dashboard/static/js/app/view-jobs-all.2017.3.5.js
@@ -317,7 +317,7 @@ require([
             var href;
             var nodeId;
 
-            href = '/boot/all/job/';
+            href = '/test/job/';
             href += data;
             href += '/branch/';
             href += object.git_branch;

--- a/app/dashboard/static/js/app/view-jobs-job-branch.2017.4.js
+++ b/app/dashboard/static/js/app/view-jobs-job-branch.2017.4.js
@@ -358,7 +358,7 @@ require([
          * Wrapper to provide the href.
         **/
         function _renderTestCount(data, type) {
-            var href = '/boot/all/job/';
+            var href = '/test/job/';
             href += gJobName;
             href += '/branch/';
             href += gBranchName;

--- a/app/dashboard/static/js/app/view-jobs-job.2017.4.js
+++ b/app/dashboard/static/js/app/view-jobs-job.2017.4.js
@@ -355,7 +355,7 @@ require([
             var href;
             var nodeId;
 
-            href = '/boot/all/job/';
+            href = '/test/job/';
             href += gJobName;
             href += '/branch/';
             href += object.git_branch;

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.1.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.1.js
@@ -1,0 +1,386 @@
+/*!
+ * kernelci dashboard.
+ *
+ * Copyright (C) 2020 Collabora Limited
+ * Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+require([
+    'jquery',
+    'utils/init',
+    'utils/html',
+    'utils/error',
+    'utils/request',
+    'utils/table',
+    'tables/test',
+    'charts/passpie',
+], function($, init, html, error, request, table, ttest, chart) {
+    'use strict';
+    var gJob;
+    var gBranch;
+    var gKernel;
+    var gPlansTable;
+
+    setTimeout(function() {
+        document.getElementById('li-test').setAttribute('class', 'active');
+    }, 15);
+
+    function detailsFailed() {
+        html.replaceByClassTxt('loading-content', '?');
+    }
+
+    function updateDetails(results) {
+        var job;
+        var branch;
+        var kernel;
+        var commit;
+        var describeNode;
+        var buildsLink;
+        var gitNode;
+        var createdOn;
+        var dateNode;
+
+        job = results.job;
+        branch = results.git_branch;
+        kernel = results.kernel;
+        commit = results.git_commit;
+
+        describeNode = html.tooltip();
+        describeNode.title =
+            "Build reports for &#171;" + job + "&#187; - " + kernel;
+        buildsLink = document.createElement('a');
+        buildsLink.href = "/build/" + job + "/kernel/" + kernel;
+        buildsLink.appendChild(html.build());
+        describeNode.appendChild(document.createTextNode(kernel));
+        describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        describeNode.appendChild(buildsLink);
+
+        gitNode = document.createElement('a')
+        gitNode.appendChild(document.createTextNode(results.git_url))
+        gitNode.href = results.git_url
+        gitNode.title = "Git URL" /* ToDo: link to commit when possible */
+
+        createdOn = new Date(results.created_on.$date);
+        dateNode = document.createElement('time');
+        dateNode.setAttribute('datetime', createdOn.toISOString());
+        dateNode.appendChild(
+            document.createTextNode(createdOn.toCustomISODate()));
+
+        html.replaceContent(
+            document.getElementById('tree'),
+            document.createTextNode(job));
+        html.replaceContent(
+            document.getElementById('git-branch'),
+            document.createTextNode(branch));
+        html.replaceContent(
+            document.getElementById('git-describe'), describeNode)
+        html.replaceContent(
+            document.getElementById('git-url'), gitNode);
+        html.replaceContent(
+            document.getElementById('git-commit'),
+            document.createTextNode(commit));
+        html.replaceContent(
+            document.getElementById('job-date'), dateNode);
+    }
+
+    function chartCountFailed() {
+        /* The chart will not be shown */
+    }
+
+    function updateChart(response) {
+        function countTests(response) {
+            var results = response.result;
+            var total = results[0].result[0].count;
+            var pass = results[1].result[0].count;
+            var regressions = results[2].result[0].count;
+            var unknown = results[3].result[0].count;
+
+            return [total, [pass, regressions, unknown]];
+        }
+
+        chart.testpie({
+            element: 'test-chart',
+            countFunc: countTests,
+            response: response,
+            size: {
+                height: 140,
+                width: 140
+            },
+            radius: {inner: -12.5, outer: 0},
+        });
+    }
+
+    function plansFailed() {
+        html.removeElement(document.getElementById('table-loading'));
+        html.replaceContent(
+            document.getElementById('table-div'),
+            html.errorDiv('No test data available.')
+        );
+    }
+
+    function updatePlansTable(results) {
+        var columns;
+
+        function _testColumnTitle() {
+            var tooltipNode;
+
+            tooltipNode = html.tooltip();
+            tooltipNode.setAttribute(
+                'title', 'Total/Successful/Regressions/Other test results');
+            tooltipNode.appendChild(
+                document.createTextNode('Test Results'));
+
+            return tooltipNode.outerHTML;
+        }
+
+        function _renderTestCount(data, type) {
+            return ttest.renderTestCount({data: data, type: type})
+        }
+
+        columns = [
+            {
+                data: 'name',
+                title: 'Test Plan',
+                type: 'string',
+                className: 'test-group-column',
+            },
+            {
+                data: 'name',
+                title: _testColumnTitle(),
+                type: 'string',
+                searchable: false,
+                orderable: false,
+                className: 'test-count pull-center',
+                render: _renderTestCount,
+            },
+            {
+                data: 'created_on',
+                title: 'Date',
+                type: 'date',
+                className: 'date-column pull-center',
+                render: ttest.renderDate,
+            },
+        ]
+
+        gPlansTable
+            .data(results)
+            .columns(columns)
+            .order([0, 'asc'])
+            .rowURL('/test/job/%(job)s/branch/%(git_branch)s/kernel/%(kernel)s/plan/%(name)s/')
+            .rowURLElements(['job', 'git_branch', 'kernel', 'name'])
+            .paging(false)
+            .info(false)
+            .draw();
+    }
+
+    function getBatchCountFailed() {
+        plansFailed();
+    }
+
+    function getBatchCountDone(response) {
+        function parseBatchData(data) {
+            html.replaceContent(
+                document.getElementById(data.operation_id),
+                document.createTextNode(data.result[0].count));
+        }
+
+        response.result.forEach(parseBatchData)
+    }
+
+    function getBatchCount(results) {
+        var batchOps;
+        var deferred;
+
+        function createBatchOp(result) {
+            var job = result.job;
+            var kernel = result.kernel;
+            var branch = result.git_branch;
+            var plan = result.name;
+            var qStr;
+
+            qStr = 'job=' + job;
+            qStr += '&kernel=' + kernel;
+            qStr += '&git_branch=' + branch;
+            qStr += '&plan=' + plan;
+
+            /* Total number of test cases */
+            batchOps.push({
+                method: 'GET',
+                operation_id: 'test-total-count-' + plan,
+                resource: 'count',
+                document: 'test_case',
+                query: qStr,
+            });
+
+            /* Number of passing test cases */
+            batchOps.push({
+                method: 'GET',
+                operation_id: 'test-success-count-' + plan,
+                resource: 'count',
+                document: 'test_case',
+                query: qStr + '&status=PASS',
+            });
+
+            /* Number of test case regressions */
+            batchOps.push({
+                method: 'GET',
+                operation_id: 'test-fail-count-' + plan,
+                resource: 'count',
+                document: 'test_regression',
+                query: qStr,
+            });
+
+            /* Number of unknown test results */
+            batchOps.push({
+                method: 'GET',
+                operation_id: 'test-unknown-count-' + plan,
+                resource: 'count',
+                document: 'test_case',
+                query: qStr + '&status=FAIL&status=SKIP&regression_id=null',
+            });
+        }
+
+        batchOps = [];
+        results.forEach(createBatchOp)
+        deferred = request.post(
+            '/_ajax/batch', JSON.stringify({batch: batchOps}));
+
+        $.when(deferred)
+            .fail(error.error, getBatchCountFailed)
+            .done(getBatchCountDone)
+    }
+
+    function getPlansFailed() {
+        detailsFailed();
+        plansFailed();
+    }
+
+    function getPlansDone(response) {
+        if (response.result.length === 0) {
+            getPlansFailed();
+            return
+        }
+
+        updateDetails(response.result[0])
+        updatePlansTable(response.result)
+        getBatchCount(response.result)
+    }
+
+    function getPlans() {
+        var data;
+        var deferred;
+
+        data = {
+            aggregate: 'name',
+            job: gJob,
+            git_branch: gBranch,
+            kernel: gKernel,
+            parent_id: 'null',
+            sort: 'name',
+            field: [
+                'name',
+                'created_on',
+                'job',
+                'git_branch',
+                'git_commit',
+                'git_url',
+                'kernel',
+            ],
+        };
+
+        deferred = request.get('/_ajax/test/group', data)
+        $.when(deferred)
+            .fail(error.error, getPlansFailed)
+            .done(getPlansDone);
+    }
+
+    function getTestCount() {
+        var qStr;
+        var batchOps;
+        var deferred;
+
+        qStr = 'job=' + gJob;
+        qStr += '&kernel=' + gKernel;
+        qStr += '&git_branch=' + gBranch;
+
+        batchOps = []
+
+        /* Total number of test cases */
+        batchOps.push({
+            method: 'GET',
+            operation_id: 'test-total-count',
+            resource: 'count',
+            document: 'test_case',
+            query: qStr,
+        });
+
+        /* Number of passing test cases */
+        batchOps.push({
+            method: 'GET',
+            operation_id: 'test-success-count',
+            resource: 'count',
+            document: 'test_case',
+            query: qStr + '&status=PASS',
+        });
+
+        /* Number of test case regressions */
+        batchOps.push({
+            method: 'GET',
+            operation_id: 'test-fail-count',
+            resource: 'count',
+            document: 'test_regression',
+            query: qStr,
+        });
+
+        /* Number of unknown test results */
+        batchOps.push({
+            method: 'GET',
+            operation_id: 'test-unknown-count',
+            resource: 'count',
+            document: 'test_case',
+            query: qStr + '&status=FAIL&status=SKIP&regression_id=null',
+        });
+
+        deferred = request.post(
+            '/_ajax/batch', JSON.stringify({batch: batchOps}));
+
+        $.when(deferred)
+            .fail(error.error, chartCountFailed)
+            .done(updateChart)
+    }
+
+    if (document.getElementById('job-name') !== null) {
+        gJob = document.getElementById('job-name').value;
+    }
+    if (document.getElementById('branch-name') !== null) {
+        gBranch = document.getElementById('branch-name').value;
+    }
+    if (document.getElementById('kernel-name') !== null) {
+        gKernel = document.getElementById('kernel-name').value;
+    }
+
+    gPlansTable = table({
+        tableId: 'planstable',
+        tableLoadingDivId: 'table-loading',
+        tableDivId: 'table-div',
+    });
+
+    setTimeout(getPlans, 10);
+    setTimeout(getTestCount, 10);
+
+    setTimeout(init.hotkeys, 50);
+    setTimeout(init.tooltip, 50);
+});

--- a/app/dashboard/static/js/build.js
+++ b/app/dashboard/static/js/build.js
@@ -13,8 +13,8 @@
  * Author: lollivier <lollivier@baylibre.com>
  *
  * kernelci dashboard.
- * 
- * 
+ *
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -100,6 +100,7 @@
             'app/view-tests-board-job': 'app/view-tests-board-job.2018.9',
             'app/view-tests-board-job-kernel': 'app/view-tests-board-job-kernel.2018.9',
             'app/view-tests-group-id': 'app/view-tests-group-id.2018.9',
+            'app/view-tests-job-branch-kernel': 'app/view-tests-job-branch-kernel.2020.1',
         }
     },
     shim: {
@@ -157,6 +158,7 @@
         {name: 'app/view-tests-board-job.2018.9'},
         {name: 'app/view-tests-board-job-kernel.2018.9'},
         {name: 'app/view-tests-group-id.2018.9'},
+        {name: 'app/view-tests-job-branch-kernel.2020.1'},
         {name: 'kci-boot-compare'},
         {name: 'kci-boots-all'},
         {name: 'kci-boots-all-job'},
@@ -192,6 +194,7 @@
         {name: 'kci-tests-board'},
         {name: 'kci-tests-board-job'},
         {name: 'kci-tests-board-job-kernel'},
+        {name: 'kci-tests-job-branch-kernel'},
         {name: 'kci-tests-group-id'}
     ]
 })

--- a/app/dashboard/static/js/common.js
+++ b/app/dashboard/static/js/common.js
@@ -13,8 +13,8 @@
  * Author: lollivier <lollivier@baylibre.com>
  *
  * kernelci dashboard.
- * 
- * 
+ *
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -96,6 +96,7 @@ require.config({
             'app/view-tests-board-job': 'app/view-tests-board-job.2018.9',
             'app/view-tests-board-job-kernel': 'app/view-tests-board-job-kernel.2018.9',
             'app/view-tests-group-id': 'app/view-tests-group-id.2018.9',
+            'app/view-tests-job-branch-kernel': 'app/view-tests-job-branch-kernel.2020.1',
         }
     },
     shim: {

--- a/app/dashboard/static/js/kci-tests-job-branch-kernel.js
+++ b/app/dashboard/static/js/kci-tests-job-branch-kernel.js
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (C) 2020 Collabora Limited
+ * Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+ *
+ * kernelci dashboard.
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+require(['common'], function() {
+    'use strict';
+    require(['app/view-tests-job-branch-kernel']);
+});

--- a/app/dashboard/templates/tests-job-branch-kernel.html
+++ b/app/dashboard/templates/tests-job-branch-kernel.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{%- block meta -%}
+<meta name="csrf-token" content="{{ csrf_token_r() }}">
+{%- endblock %}
+{%- block title %}{{ page_title|safe }}{%- endblock %}
+{%- block head %}
+{{ super() }}
+<style type="text/css">
+    .conflicts-table > thead {
+        font-weight: bold;
+    }
+    input[type="checkbox"] {
+        display: block;
+        margin: 0 auto;
+    }
+</style>
+<link rel="stylesheet" type="text/css" href="/static/css/dataTables.bootstrap-1.10.11.css">
+<link rel="stylesheet" type="text/css" href="/static/css/kci-graphs-2015.9.1.css">
+{%- endblock %}
+{%- block content %}
+<div class="row">
+    <div class="page-header">
+        <h3 id="details">{{ body_title|safe }}</h3>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7">
+        <dl class="dl-horizontal">
+            <dt>Tree</dt>
+            <dd class="loading-content" id="tree">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git branch</dt>
+            <dd class="loading-content" id="git-branch">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git describe</dt>
+            <dd class="loading-content" id="git-describe">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git URL</dt>
+            <dd class="loading-content" id="git-url">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git commit</dt>
+            <dd class="loading-content" id="git-commit">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw" aria-hidden="true" title="Loading"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Date</dt>
+            <dd class="loading-content" id="job-date">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+        </dl>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+        <div id="test-chart" class="chart-div pull-center"></div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="page-header">
+            <h3>Available Test Plans</h3>
+        </div>
+        <div id="table-loading" class="pull-center">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
+                &nbsp;retrieving test data&hellip;
+            </small>
+        </div>
+    {%- if is_mobile %}
+        <div class="table-responsive" id="table-div">
+    {%- else %}
+        <div class="table" id="table-div">
+    {%- endif %}
+            <table class="table table-hover table-striped table-condensed clickable-table big-table" id="planstable">
+            </table>
+        </div>
+    </div>
+</div>
+<input type="hidden" id="job-name" value="{{ job }}">
+<input type="hidden" id="branch-name" value="{{ branch }}">
+<input type="hidden" id="kernel-name" value="{{ kernel }}">
+{%- endblock %}
+{%- block scripts %}
+<script data-main="/static/js/kci-tests-job-branch-kernel" src="/static/js/lib/require.js"></script>
+{%- endblock %}

--- a/app/dashboard/utils/route.py
+++ b/app/dashboard/utils/route.py
@@ -392,3 +392,13 @@ def init():
         as_view("tests-board-job-kernel-view"),
         methods=["GET"]
     )
+
+    add_rule(
+        (
+            "/test/job/<string:job>/branch/<string:branch>/"
+            "kernel/<string:kernel>/"
+        ),
+        view_func=vtest.TestJobBranchKernelView.
+        as_view("test-job-branch-kernel"),
+        methods=["GET"]
+    )

--- a/app/dashboard/views/test.py
+++ b/app/dashboard/views/test.py
@@ -159,3 +159,24 @@ class TestsGroupIdView(TestGenericView):
             "tests-group-id.html",
             group_id=kwargs["uid"],
             page_title=self.TESTS_PAGE_TITLE)
+
+
+class TestJobBranchKernelView(TestGenericView):
+
+    def dispatch_request(self, **kwargs):
+        job, branch, kernel = (kwargs[k] for k in ['job', 'branch', 'kernel'])
+        page_title = "{} &mdash; {}/{} {}".format(
+            self.TESTS_PAGE_TITLE, job, branch, kernel)
+        body_title = (
+            "Test Results: &#171;{}&#187 - {} <small>({})</small>".format(
+                job, kernel, branch)
+        )
+
+        return render_template(
+            "tests-job-branch-kernel.html",
+            page_title=page_title,
+            body_title=body_title,
+            job=job,
+            branch=branch,
+            kernel=kernel
+        )


### PR DESCRIPTION
Add view to show a list of test plans for a given combination of job/branch/kernel.  Update links from the jobs view to use it instead of the corresponding boots view.