### PR TITLE
Disable sorting by test and build result summaries on jobs views

### DIFF
--- a/app/dashboard/static/js/app/view-jobs-job-branch.2017.4.js
+++ b/app/dashboard/static/js/app/view-jobs-job-branch.2017.4.js
@@ -412,12 +412,16 @@ require([
                     title: _buildColumTitle(),
                     type: 'string',
                     className: 'build-count pull-center',
+                    orderable: false,
+                    searchable: false,
                     render: _renderBuildCount
                 },
                 {
                     data: 'kernel',
                     title: _testColumnTitle(),
                     type: 'string',
+                    orderable: false,
+                    searchable: false,
                     className: 'test-count pull-center',
                     render: _renderTestCount
                 },

--- a/app/dashboard/static/js/app/view-jobs-job.2017.4.js
+++ b/app/dashboard/static/js/app/view-jobs-job.2017.4.js
@@ -481,6 +481,8 @@ require([
                     data: 'kernel',
                     title: _buildColumTitle(),
                     type: 'string',
+                    orderable: false,
+                    searchable: false,
                     className: 'build-count pull-center',
                     render: _renderBuildCount
                 },
@@ -488,6 +490,8 @@ require([
                     data: 'kernel',
                     title: _testColumnTitle(),
                     type: 'string',
+                    orderable: false,
+                    searchable: false,
                     className: 'test-count pull-center',
                     render: _renderTestCount
                 },


### PR DESCRIPTION
The summaries with the test and build results can't be used to sort
the tables so disable the option to do so.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>