### PR TITLE
requirements: add werkzeug==0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+werkzeug==0.16
 Flask-Cache
 Flask-WTF==0.11
 Flask==1.0


### PR DESCRIPTION
When installing on debian/buster the version of werkzeug installed
doesn't match the version of Flask-WTF and results in the backtrace
below.

To fix, need an older version of werkzeug.

Traceback (most recent call last):
  File "./server.py", line 18, in <module>
    from dashboard import app
  File "./dashboard/__init__.py", line 41, in <module>
    from flask_wtf.csrf import (
  File "/usr/local/lib/python2.7/dist-packages/flask_wtf/__init__.py", line 17, in <module>
    from .recaptcha import *
  File "/usr/local/lib/python2.7/dist-packages/flask_wtf/recaptcha/__init__.py", line 2, in <module>
    from .fields import *
  File "/usr/local/lib/python2.7/dist-packages/flask_wtf/recaptcha/fields.py", line 4, in <module>
    from .validators import Recaptcha
  File "/usr/local/lib/python2.7/dist-packages/flask_wtf/recaptcha/validators.py", line 9, in <module>
    from werkzeug import url_encode
ImportError: cannot import name url_encode

Signed-off-by: Kevin Hilman <khilman@baylibre.com>