### PR TITLE
Add requirement to use werkzeug  v0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask==1.0
 redis==2.10.5
 requests
 pymongo==3.9.0
+werkzeug==0.16


### PR DESCRIPTION
As a side effect of updating other packages, werkzeug started to get
installed with v1.0 which isn't compatible with the current uwsgi
service.  Pin it down to the known working version v0.16 for now.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>