### PR TITLE
WIP fix detecting regressions with clang

### DIFF
--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.1.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.1.js
@@ -347,6 +347,8 @@ require([
     }
 
     function getRegressionsDone(response) {
+        console.log("getRegressionsDone");
+        console.log(response);
         updateRegressions(response.result);
         updateButtons(gPanel);
     }


### PR DESCRIPTION
This is to fix the issue where regressions with a gcc-built kernel are shown but not with clang.