### PR TITLE
T18939 add view with test results for a given test plan id

### DIFF
--- a/app/dashboard/static/css/kci-base-2020.2.css
+++ b/app/dashboard/static/css/kci-base-2020.2.css
@@ -321,3 +321,8 @@ div.qemu-command {
     overflow-wrap: break-word;
     word-break: break-word;
 }
+ul.measurements {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}

--- a/app/dashboard/static/js/app/charts/pie.js
+++ b/app/dashboard/static/js/app/charts/pie.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -94,21 +94,42 @@ define([
                     .text(piechart.settings().text);
 
                 if (piechart.settings().legend) {
-                    $('#success-cell')
+                    var ids = piechart.settings().legendIds;
+                    var titles = piechart.settings().legendTitles;
+
+                    if (!ids) {
+                        ids = {
+                            'pass': '#success-cell',
+                            'fail': '#fail-cell',
+                            'unknown': '#unknown-cell',
+                        };
+                    }
+
+                    if (!titles) {
+                        titles = {
+                            'pass': 'Successful',
+                            'fail': 'Failed',
+                            'unknown': 'Unknown',
+                        };
+                    }
+
+                    $(ids['pass'])
                         .empty()
                         .append(
                             p.sprintf(
-                                sTooltipFmt, 'Successful', data.values[0]))
+                                sTooltipFmt, titles['pass'], data.values[0]))
                         .css('border-bottom-color', color[0]);
-                    $('#fail-cell')
+                    $(ids['fail'])
                         .empty()
                         .append(
-                            p.sprintf(sTooltipFmt, 'Failed', data.values[1]))
+                            p.sprintf(
+                                sTooltipFmt, titles['fail'], data.values[1]))
                         .css('border-bottom-color', color[1]);
-                    $('#unknown-cell')
+                    $(ids['unknown'])
                         .empty()
                         .append(
-                            p.sprintf(sTooltipFmt, 'Unknown', data.values[2]))
+                            p.sprintf(
+                                sTooltipFmt, titles['unknown'], data.values[2]))
                         .css('border-bottom-color', color[2]);
                 }
             });

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
@@ -1,0 +1,34 @@
+/*!
+ * kernelci dashboard.
+ *
+ * Copyright (C) 2020 Collabora Limited
+ * Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+require([
+    'jquery',
+    'utils/init',
+], function($, init) {
+    'use strict';
+
+    setTimeout(function() {
+        document.getElementById('li-test').setAttribute('class', 'active');
+    }, 15);
+
+    setTimeout(init.hotkeys, 50);
+    setTimeout(init.tooltip, 50);
+});

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
@@ -149,6 +149,17 @@ require([
             element: 'test-chart',
             countFunc: countTests,
             response: response,
+            legend: true,
+            legendIds: {
+                'pass': '#show-pass',
+                'fail': '#show-fail',
+                'unknown': '#show-unknown',
+            },
+            legendTitles: {
+                'pass': 'Successful',
+                'fail': 'Regressions',
+                'unknown': 'Unknown',
+            },
             size: {
                 height: 200,
                 width: 200,

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
@@ -135,6 +135,28 @@ require([
         var columns;
         var data;
 
+        function _renderMeasurements(measurements, type) {
+            var mesList;
+
+            if (type != "display")
+                return;
+
+            if (!measurements.length)
+                return "-";
+
+            mesList = document.createElement('ul');
+            mesList.className = 'measurements';
+
+            measurements.forEach(function(data) {
+                var mes = document.createElement('li');
+                var msg = data['value'] + " " + data['unit'];
+                mes.appendChild(document.createTextNode(msg));
+                mesList.appendChild(mes);
+            });
+
+            return mesList.outerHTML;
+        }
+
         function _renderStatus(data, type) {
             if (type == "display") {
                 var node = document.createElement('div');
@@ -148,6 +170,7 @@ require([
         data = [];
         results.forEach(function(item) {
             var status;
+            var measurements;
 
             if (item.status == 'PASS')
                 status = 'PASS';
@@ -157,9 +180,10 @@ require([
                 status = 'UNKNOWN';
 
             data.push({
-                'test_case_path': item.test_case_path,
-                'status': status,
                 '_id': item._id,
+                'test_case_path': item.test_case_path,
+                'measurements': item.measurements,
+                'status': status,
             });
         });
 
@@ -169,6 +193,15 @@ require([
                 data: 'test_case_path',
                 type: 'string',
                 className: 'test-group-column',
+            },
+            {
+                title: 'Measurements',
+                data: 'measurements',
+                type: 'string',
+                className: 'test-group-column',
+                searchable: false,
+                orderable: false,
+                render: _renderMeasurements,
             },
             {
                 title: 'Status',

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
@@ -22,12 +22,139 @@
 require([
     'jquery',
     'utils/init',
-], function($, init) {
+    'utils/request',
+    'utils/error',
+    'utils/html',
+    'utils/urls',
+    'components/test/common',
+], function($, init, request, error, html, urls, tcommon) {
     'use strict';
+
+    var gPlanId;
+    var gFileServer;
 
     setTimeout(function() {
         document.getElementById('li-test').setAttribute('class', 'active');
     }, 15);
+
+    function detailsFailed() {
+        html.replaceByClassTxt('loading-content', '?');
+    }
+
+    function updateDetails(results) {
+        var job;
+        var kernel;
+        var treeNode;
+        var jobLink;
+        var describeNode;
+        var buildsLink;
+        var gitNode;
+        var createdOn;
+        var dateNode;
+        var translatedURI;
+        var logNode;
+
+        job = results.job;
+        kernel = results.kernel;
+
+        treeNode = html.tooltip();
+        treeNode.title = "Details for tree &#171;" + job + "&#187;"
+        jobLink = document.createElement('a');
+        jobLink.href = "/job/" + job + "/";
+        jobLink.appendChild(html.tree());
+        treeNode.appendChild(document.createTextNode(job));
+        treeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        treeNode.appendChild(jobLink);
+
+        describeNode = html.tooltip();
+        describeNode.title =
+            "Build reports for &#171;" + job + "&#187; - " + kernel;
+        buildsLink = document.createElement('a');
+        buildsLink.href = "/build/" + job + "/kernel/" + kernel;
+        buildsLink.appendChild(html.build());
+        describeNode.appendChild(document.createTextNode(kernel));
+        describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        describeNode.appendChild(buildsLink);
+
+        gitNode = document.createElement('a');
+        gitNode.appendChild(document.createTextNode(results.git_url));
+        gitNode.href = results.git_url;
+        gitNode.title = "Git URL";
+
+        createdOn = new Date(results.created_on.$date);
+        dateNode = document.createElement('time');
+        dateNode.setAttribute('datetime', createdOn.toISOString());
+        dateNode.appendChild(
+            document.createTextNode(createdOn.toCustomISODate()));
+
+        translatedURI = urls.createFileServerURL(gFileServer, results);
+        logNode = tcommon.logsNode(
+            results.boot_log, results.boot_log_html, results.lab_name,
+            translatedURI[0], translatedURI[1]);
+
+        html.replaceContent(
+            document.getElementById('lab-name'),
+            document.createTextNode(results.lab_name));
+        html.replaceContent(
+            document.getElementById('plan-name'),
+            document.createTextNode(results.name));
+        html.replaceContent(
+            document.getElementById('device-type'),
+            document.createTextNode(results.device_type));
+        html.replaceContent(
+            document.getElementById('tree'), treeNode);
+        html.replaceContent(
+            document.getElementById('git-branch'),
+            document.createTextNode(results.git_branch));
+        html.replaceContent(
+            document.getElementById('git-describe'), describeNode)
+        html.replaceContent(
+            document.getElementById('git-url'), gitNode);
+        html.replaceContent(  /* ToDo: link to commit when possible */
+            document.getElementById('git-commit'),
+            document.createTextNode(results.git_commit));
+        html.replaceContent(
+            document.getElementById('arch'),
+            document.createTextNode(results.arch));
+        html.replaceContent(
+            document.getElementById('defconfig'),
+            document.createTextNode(results.defconfig_full));
+        html.replaceContent(
+            document.getElementById('compiler'),
+            document.createTextNode(results.compiler_version_full));
+        html.replaceContent(
+            document.getElementById('job-date'), dateNode);
+        html.replaceContent(
+            document.getElementById('job-log'), logNode);
+    }
+
+    function getPlanFailed() {
+        detailsFailed();
+    }
+
+    function getPlanDone(response) {
+        updateDetails(response.result[0]);
+    }
+
+    function getPlan() {
+        if (!gPlanId) {
+            getPlanFailed();
+            return
+        }
+
+        $.when(request.get('/_ajax/test/group', {id: gPlanId}))
+            .fail(error.error, getPlanFailed)
+            .done(getPlanDone);
+    }
+
+    if (document.getElementById('plan-id') !== null) {
+        gPlanId = document.getElementById('plan-id').value;
+    }
+    if (document.getElementById('file-server') !== null) {
+        gFileServer = document.getElementById('file-server').value;
+    }
+
+    setTimeout(getPlan, 10);
 
     setTimeout(init.hotkeys, 50);
     setTimeout(init.tooltip, 50);

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
@@ -134,21 +134,18 @@ require([
             document.getElementById('job-log'), logNode);
     }
 
-    function updateChart(response) {
-        function countTests(response) {
-            var results = response.result;
-            var total = results[0].result[0].count;
-            var pass = results[1].result[0].count;
-            var regressions = results[2].result[0].count;
-            var unknown = results[3].result[0].count;
-
-            return [total, [pass, regressions, unknown]];
+    function updateChart(testCount) {
+        function countTests(tc) {
+            return [
+                tc['total'],
+                [tc['pass'], tc['regressions'], tc['unknown']]
+            ];
         }
 
         pieChart.testpie({
             element: 'test-chart',
             countFunc: countTests,
-            response: response,
+            response: testCount,
             legend: true,
             legendIds: {
                 'pass': '#show-pass',
@@ -165,6 +162,43 @@ require([
                 width: 200,
             },
             radius: {inner: -30, outer: -42},
+        });
+    }
+
+    function listenForTableEvents(testCount) {
+        var btnList = ['total', 'pass', 'regressions', 'unknown'];
+
+        function _tableFilter(event) {
+            var activeId = event.target.id;
+            var status = activeId.substring('btn-'.length);
+
+            if (status == 'total') {
+                status = '';
+            } else if (status == 'regressions') {
+                status = 'fail';
+            }
+
+            gTestsTable.table.column(2).search(status).draw();
+
+            btnList.forEach(function(id) {
+                var btnId = 'btn-' + id;
+                var ele = document.getElementById(btnId);
+
+                if (btnId == activeId) {
+                    html.addClass(ele, 'active');
+                } else {
+                    html.removeClass(ele, 'active');
+                }
+            });
+        }
+
+        btnList.forEach(function(id) {
+            var ele = document.getElementById('btn-' + id);
+            ele.addEventListener('click', _tableFilter, true);
+            if (testCount[id])
+                ele.removeAttribute('disabled');
+            if (id == 'total')
+                html.addClass(ele, 'active');
         });
     }
 
@@ -307,7 +341,17 @@ require([
     }
 
     function testCountDone(response) {
-        updateChart(response);
+        var results = response.result;
+        var testCount;
+
+        testCount = {
+            'total': results[0].result[0].count,
+            'pass': results[1].result[0].count,
+            'regressions': results[2].result[0].count,
+            'unknown': results[3].result[0].count,
+        };
+        updateChart(testCount);
+        listenForTableEvents(testCount);
     }
 
     function getTestCount(results) {

--- a/app/dashboard/static/js/build.js
+++ b/app/dashboard/static/js/build.js
@@ -98,6 +98,7 @@
             'app/view-tests-board-job': 'app/view-tests-board-job.2018.9',
             'app/view-tests-board-job-kernel': 'app/view-tests-board-job-kernel.2018.9',
             'app/view-tests-group-id': 'app/view-tests-group-id.2018.9',
+            'app/view-tests-plan-id': 'app/view-tests-plan-id.2020.2',
             'app/view-tests-job-branch-kernel': 'app/view-tests-job-branch-kernel.2020.1',
             'app/view-tests-job-branch-kernel-plan': 'app/view-tests-job-branch-kernel-plan.2020.1',
         }
@@ -153,6 +154,7 @@
         {name: 'app/view-tests-board-job.2018.9'},
         {name: 'app/view-tests-board-job-kernel.2018.9'},
         {name: 'app/view-tests-group-id.2018.9'},
+        {name: 'app/view-tests-plan-id.2020.2'},
         {name: 'app/view-tests-job-branch-kernel.2020.1'},
         {name: 'app/view-tests-job-branch-kernel-plan.2020.1'},
         {name: 'kci-boots-all'},
@@ -187,6 +189,7 @@
         {name: 'kci-tests-board-job'},
         {name: 'kci-tests-board-job-kernel'},
         {name: 'kci-tests-job-branch-kernel'},
+        {name: 'kci-tests-plan-id'},
         {name: 'kci-tests-group-id'}
     ]
 })

--- a/app/dashboard/static/js/common.js
+++ b/app/dashboard/static/js/common.js
@@ -1,7 +1,7 @@
 /*!
  * Copyright (C) Collabora Limited 2020
  * Author: Alexandra Pereira <alexandra.pereira@collabora.com>
- * 
+ *
  * Copyright (C) Linaro Limited 2015,2016,2017,2019
  * Author: Matt Hart <matthew.hart@linaro.org>
  * Author: Milo Casagrande <milo.casagrande@linaro.org>
@@ -95,6 +95,7 @@ require.config({
             'app/view-tests-board-job': 'app/view-tests-board-job.2018.9',
             'app/view-tests-board-job-kernel': 'app/view-tests-board-job-kernel.2018.9',
             'app/view-tests-group-id': 'app/view-tests-group-id.2018.9',
+            'app/view-tests-plan-id': 'app/view-tests-plan-id.2020.2',
             'app/view-tests-job-branch-kernel': 'app/view-tests-job-branch-kernel.2020.1',
             'app/view-tests-job-branch-kernel-plan': 'app/view-tests-job-branch-kernel-plan.2020.1',
         }

--- a/app/dashboard/static/js/kci-tests-plan-id.js
+++ b/app/dashboard/static/js/kci-tests-plan-id.js
@@ -1,0 +1,5 @@
+/*! Kernel CI Dashboard | Licensed under the GNU GPL v3 (or later) */
+require(['common', 'app/utils/date'], function() {
+    'use strict';
+    require(['app/view-tests-plan-id']);
+});

--- a/app/dashboard/templates/tests-plan-id.html
+++ b/app/dashboard/templates/tests-plan-id.html
@@ -77,7 +77,22 @@
     </dl>
     </div>
     <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
-        <div id="test-chart" class="chart-div pull-center"></div>
+        <div id="pie-chart" class="chart-div pull-center">
+          <div id="pie-chart-heading">
+              <table id="pie-chart-legend" class="pie-chart">
+                  <tbody>
+                      <tr>
+                          <td id="show-pass" class="click-btn">0</td>
+                          <td>&nbsp;/&nbsp;</td>
+                          <td id="show-fail" class="click-btn">0</td>
+                          <td>&nbsp;/&nbsp;</td>
+                          <td id="show-unknown" class="click-btn">0</td>
+                      </tr>
+                  </tbody>
+              </table>
+            </div>
+            <div id="test-chart"></div>
+        </div>
     </div>
 </div>
 <div class="row">

--- a/app/dashboard/templates/tests-plan-id.html
+++ b/app/dashboard/templates/tests-plan-id.html
@@ -100,6 +100,16 @@
         <div class="page-header">
             <h4>Test Results</h4>
         </div>
+        <div class="row">
+            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+                <div class="btn-group btn-group-sm">
+                    <button id="btn-total" type="button" class="btn btn-default" disabled>All</button>
+                    <button id="btn-pass" type="button" class="btn btn-default" disabled>Successful</button>
+                    <button id="btn-regressions" type="button" class="btn btn-default" disabled>Regressions</button>
+                    <button id="btn-unknown" type="button" class="btn btn-default" disabled>Unknown</button>
+                </div>
+            </div>
+        </div>
         <div id="table-loading" class="pull-center">
             <small>
                 <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>

--- a/app/dashboard/templates/tests-plan-id.html
+++ b/app/dashboard/templates/tests-plan-id.html
@@ -6,7 +6,71 @@
 {%- block content %}
 <div class="row">
     <div class="page-header">
-    <h3 id="body-title">Test details for test plan&nbsp;</h3>
+    <h3 id="body-title">Test plan run: «<span id="plan-name">&hellip;</span>» on «<span id="device-type">&hellip;</span>» <small>(<span id="lab-name">&hellip;</span>)</small></h3>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+    <dl class="dl-horizontal" id="dl-right">
+        <dt>Tree</dt>
+        <dd id="tree" class="loading-content">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+            </small>
+        </dd>
+        <dt>Git branch<dt>
+        <dd id="git-branch" class="loading-content">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+            </small>
+        </dd>
+        <dt>Git describe</dt>
+        <dd id="git-describe" class="loading-content">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+            </small>
+        </dd>
+        <dt>Git URL</dt>
+        <dd id="git-url" class="loading-content">
+          <small>
+            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+          </small>
+        </dd>
+        <dt>Git commit</dt>
+        <dd class="loading-content" id="git-commit">
+          <small>
+            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+          </small>
+        </dd>
+        <dt>Architecture</dt>
+        <dd id="arch" class="loading-content">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+            </small>
+        </dd>
+        <dt>Compiler</dt>
+        <dd id="compiler" class="loading-content">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+            </small>
+        </dd>
+        <dt>Defconfig</dt>
+        <dd id="defconfig" class="loading-content">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+            </small>
+        </dd>
+        <dt>Date</dt>
+        <dd id="job-date" class="loading-content">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+            </small>
+        </dd>
+        <dt>Job log</dt>
+        <dd id="job-log" class="loading-content">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+            </small>
+        </dd>
+    </dl>
     </div>
 </div>
 <input type="hidden" id="file-server" value='{{ config["FILE_SERVER_URL"] }}'>

--- a/app/dashboard/templates/tests-plan-id.html
+++ b/app/dashboard/templates/tests-plan-id.html
@@ -76,6 +76,9 @@
         </dd>
     </dl>
     </div>
+    <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+        <div id="test-chart" class="chart-div pull-center"></div>
+    </div>
 </div>
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">

--- a/app/dashboard/templates/tests-plan-id.html
+++ b/app/dashboard/templates/tests-plan-id.html
@@ -1,0 +1,17 @@
+{%- extends "base.html" %}
+{%- block meta -%}
+    <meta name="csrf-token" content="{{ csrf_token_r() }}">
+{%- endblock %}
+{%- block title %}{{ page_title|safe }}{%- endblock %}
+{%- block content %}
+<div class="row">
+    <div class="page-header">
+    <h3 id="body-title">Test details for test plan&nbsp;</h3>
+    </div>
+</div>
+<input type="hidden" id="file-server" value='{{ config["FILE_SERVER_URL"] }}'>
+<input type="hidden" id="plan-id" value="{{ plan_id }}">
+{%- endblock %}
+{%- block scripts %}
+<script data-main="/static/js/kci-tests-plan-id" src="/static/js/lib/require.js"></script>
+{%- endblock %}

--- a/app/dashboard/templates/tests-plan-id.html
+++ b/app/dashboard/templates/tests-plan-id.html
@@ -3,6 +3,10 @@
     <meta name="csrf-token" content="{{ csrf_token_r() }}">
 {%- endblock %}
 {%- block title %}{{ page_title|safe }}{%- endblock %}
+{%- block head %}
+{{ super() }}
+<link rel="stylesheet" type="text/css" href="/static/css/dataTables.bootstrap-1.10.11.css">
+{%- endblock %}
 {%- block content %}
 <div class="row">
     <div class="page-header">
@@ -71,6 +75,27 @@
             </small>
         </dd>
     </dl>
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="page-header">
+            <h4>Test Results</h4>
+        </div>
+        <div id="table-loading" class="pull-center">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
+                &nbsp;retrieving test data&hellip;
+            </small>
+        </div>
+    {%- if is_mobile %}
+        <div class="table-responsive" id="table-div">
+    {%- else %}
+        <div class="table" id="table-div">
+    {%- endif %}
+            <table class="table table-hover table-striped table-condensed clickable-table big-table" id="tests-table">
+            </table>
+        </div>
     </div>
 </div>
 <input type="hidden" id="file-server" value='{{ config["FILE_SERVER_URL"] }}'>

--- a/app/dashboard/utils/route.py
+++ b/app/dashboard/utils/route.py
@@ -1,6 +1,6 @@
 # Copyright (C) Collabora Limited 2020
 # Author: Alexandra Pereira <alexandra.pereira@collabora.com>
-# 
+#
 # Copyright (C) Linaro Limited 2014,2015,2016,2017,2019
 # Author: Matt Hart <matthew.hart@linaro.org>
 # Author: Milo Casagrande <milo.casagrande@linaro.org>
@@ -352,6 +352,12 @@ def init():
     add_rule(
         "/test/group/<regex(\"[A-Za-z0-9]{24}\"):uid>/",
         view_func=vtest.TestsGroupIdView.as_view("tests-group-id"),
+        methods=["GET"]
+    )
+
+    add_rule(
+        "/test/plan/id/<regex(\"[0-9a-f]{24}\"):uid>/",
+        view_func=vtest.TestsPlanIdView.as_view("tests-plan-id"),
         methods=["GET"]
     )
 

--- a/app/dashboard/views/test.py
+++ b/app/dashboard/views/test.py
@@ -161,6 +161,15 @@ class TestsGroupIdView(TestGenericView):
             page_title=self.TESTS_PAGE_TITLE)
 
 
+class TestsPlanIdView(TestGenericView):
+
+    def dispatch_request(self, **kwargs):
+        return render_template(
+            "tests-plan-id.html",
+            plan_id=kwargs["uid"],
+            page_title=self.TESTS_PAGE_TITLE)
+
+
 class TestJobBranchKernelView(TestGenericView):
 
     def dispatch_request(self, **kwargs):


### PR DESCRIPTION
Add view to show the full list of test results for a given test plan run.

Note: Details of regressions are not shown on this view as it would make it too crowded.  The next view with full details of an individual test case would be the natural place for this.