### PR TITLE
T19387 - only show failed builds when landing on page

### DIFF
--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.2.1.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.2.1.js
@@ -61,13 +61,13 @@ require([
             function(value) {
                 value.addEventListener(
                     'click', commonBtns.showHideElements, true);
-        });
+            });
         Array.prototype.forEach.call(
             document.getElementsByClassName('warn-err-btn'),
             function(value) {
                 value.addEventListener(
                     'click', buildBtns.showHideWarnErr, true);
-        });
+            });
     }
 
     function loadSavedSession() {
@@ -691,16 +691,14 @@ require([
                     .getElementById('unknown-btn').removeAttribute('disabled');
             }
 
-            setTimeout(function() {
-                if (!loadSavedSession()) {
-                    if (hasFailed) {
-                        showFailedOnly();
-                    } else {
-                        html.addClass(
-                            document.getElementById('all-btn'), 'active');
-                    }
+            setTimeout(function () {
+                if (hasFailed) {
+                    showFailedOnly();
+                } else if (!loadSavedSession()) {
+                    html.addClass(
+                        document.getElementById('all-btn'), 'active');
                 }
-            }, 0);
+            }, 1000);
 
             // Bind buttons to the correct function.
             setTimeout(bindDetailButtons, 0);


### PR DESCRIPTION
remove all session storage in order to avoid
bugs and to only show failed builds when there is any
fail on build list.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>