### PR TITLE
Add new coalesced test tab

### DIFF
--- a/app/dashboard/templates/base.html
+++ b/app/dashboard/templates/base.html
@@ -79,6 +79,12 @@
                             <i class="fa fa-stethoscope"></i>&nbsp;Tests<small>&nbsp;<sup>&#946;</sup></small>
                         </a>
                     </li>
+                    <li id="li-li-kcidb">
+                        <a id="kcidb-l" href="https://staging.kernelci.org:3000" target="_blank"
+                            title="View the KCIDB results (beta)">
+                            <i class="fa fa-stethoscope"></i>&nbsp;KCIDB<small>&nbsp;<sup>&#946;</sup></small>
+                        </a>
+                    </li>
                     <!-- Disabled as it needs fixing in kernrelci-backend
                     <li id="li-compare">
                         <a id="compare-l" href="/compare/"

--- a/app/dashboard/templates/index.html
+++ b/app/dashboard/templates/index.html
@@ -136,6 +136,15 @@
                         View latest test reports
                     </span>
                 </li>
+                <li>
+                    <a class="btn btn-default" href="https://staging.kernelci.org:3000" target="_blank" role="button">
+                        <i class="fa fa-stethoscope fa-lg"></i>
+                    </a>
+                    &nbsp;
+                    <span class="selection-label">
+                        View KCIDB results
+                    </span>
+                </li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
As the work for coalesced testing results ramp up, create a pointer
to the data for early feedback.   The change points to the internal
grafana server for now.  Can be changed later.

Signed-off-by: Don Zickus <dzickus@redhat.com>