### PR TITLE
Syntax clean-up of view-tests-*.js files

### DIFF
--- a/app/dashboard/static/js/app/view-tests-case-id.2020.3.js
+++ b/app/dashboard/static/js/app/view-tests-case-id.2020.3.js
@@ -59,7 +59,7 @@ require([
         kernel = results.kernel;
 
         treeNode = html.tooltip();
-        treeNode.title = "Details for tree &#171;" + job + "&#187;"
+        treeNode.title = "Details for tree &#171;" + job + "&#187;";
         jobLink = document.createElement('a');
         jobLink.href = "/job/" + job + "/";
         jobLink.appendChild(html.tree());
@@ -195,7 +195,7 @@ require([
             document.createTextNode(results.defconfig_full));
         defconfigPath = translatedURI[1] + "/kernel.config";
         defconfigLink.href =
-            translatedURI[0].path(defconfigPath).normalizePath().href()
+            translatedURI[0].path(defconfigPath).normalizePath().href();
         defconfigLink.title = "Defconfig URL";
         defconfigLink.insertAdjacentHTML('beforeend', '&nbsp;');
         defconfigLink.appendChild(html.external());
@@ -312,7 +312,7 @@ require([
                 className: 'pull-center',
                 render: _renderStatus,
             },
-        ]
+        ];
 
         gRegressionTable
             .data(data)
@@ -363,7 +363,7 @@ require([
     }
 
     function getCaseDone(response) {
-        var testCase = response.result[0]
+        var testCase = response.result[0];
 
         getGroup(testCase);
         getRegression(testCase);

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.1.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.1.js
@@ -70,7 +70,7 @@ require([
         commit = results.git_commit;
 
         treeNode = html.tooltip();
-        treeNode.title = "Details for tree &#171;" + job + "&#187;"
+        treeNode.title = "Details for tree &#171;" + job + "&#187;";
         jobLink = document.createElement('a');
         jobLink.href = "/job/" + job + "/";
         jobLink.appendChild(html.tree());
@@ -88,10 +88,10 @@ require([
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         describeNode.appendChild(buildsLink);
 
-        gitNode = document.createElement('a')
-        gitNode.appendChild(document.createTextNode(results.git_url))
-        gitNode.href = results.git_url
-        gitNode.title = "Git URL" /* ToDo: link to commit when possible */
+        gitNode = document.createElement('a');
+        gitNode.appendChild(document.createTextNode(results.git_url));
+        gitNode.href = results.git_url;
+        gitNode.title = "Git URL"; /* ToDo: link to commit when possible */
 
         createdOn = new Date(results.created_on.$date);
         dateNode = document.createElement('time');
@@ -105,7 +105,7 @@ require([
             document.getElementById('git-branch'),
             document.createTextNode(branch));
         html.replaceContent(
-            document.getElementById('git-describe'), describeNode)
+            document.getElementById('git-describe'), describeNode);
         html.replaceContent(
             document.getElementById('git-url'), gitNode);
         html.replaceContent(
@@ -143,7 +143,7 @@ require([
         var node;
 
         container = document.getElementById('accordion-container');
-        node = document.createElement('div')
+        node = document.createElement('div');
         node.className = 'pull-center';
         node.appendChild(document.createTextNode('No test data available'));
         html.replaceContent(container, node);
@@ -205,7 +205,7 @@ require([
             var lab = data.operation_id[0];
             var result = data.operation_id[1];
             var count = data.result[0].count;
-            labResults[lab][result] = count
+            labResults[lab][result] = count;
         }
         results.forEach(mapResults);
 
@@ -381,7 +381,7 @@ require([
         }
 
         batchOps = [];
-        results.forEach(createBatchOp)
+        results.forEach(createBatchOp);
         deferred = request.post(
             '/_ajax/batch', JSON.stringify({batch: batchOps}));
 
@@ -511,7 +511,7 @@ require([
             'plan':  gPlan,
         });
 
-        batchOps = []
+        batchOps = [];
 
         batchOps.push({
             method: 'GET',

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.1.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.1.js
@@ -196,20 +196,18 @@ require([
     function updateLabs(results) {
         var labResults = {};
 
-        function initLab(lab) {
+        Object.keys(gPanel.allLabs).forEach(function(lab) {
             labResults[lab] = {};
-        }
-        Object.keys(gPanel.allLabs).forEach(initLab);
+        });
 
-        function mapResults(data) {
+        results.forEach(function(data) {
             var lab = data.operation_id[0];
             var result = data.operation_id[1];
             var count = data.result[0].count;
             labResults[lab][result] = count;
-        }
-        results.forEach(mapResults);
+        });
 
-        function updateLab(lab) {
+        Object.keys(gPanel.allLabs).forEach(function(lab) {
             var res = labResults[lab];
 
             html.replaceContent(
@@ -217,8 +215,7 @@ require([
                 createLabResultsCount(res['total'], res['success'],
                                       res['regressions'], res['unknown'])
             );
-        }
-        Object.keys(gPanel.allLabs).forEach(updateLab);
+        });
     }
 
     function updateRegressions(results) {

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.1.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.1.js
@@ -28,7 +28,8 @@ require([
     'utils/table',
     'tables/test',
     'charts/passpie',
-], function($, init, html, error, request, table, ttest, chart) {
+    'URI',
+], function($, init, html, error, request, table, ttest, chart, URI) {
     'use strict';
     var gJob;
     var gBranch;
@@ -222,10 +223,12 @@ require([
             var plan = result.name;
             var qStr;
 
-            qStr = 'job=' + job;
-            qStr += '&kernel=' + kernel;
-            qStr += '&git_branch=' + branch;
-            qStr += '&plan=' + plan;
+            qStr = URI.buildQuery({
+                'job': job,
+                'kernel': kernel,
+                'git_branch': branch,
+                'plan': plan,
+            });
 
             /* Total number of test cases */
             batchOps.push({
@@ -299,10 +302,12 @@ require([
             var plan = result.name;
             var qStr;
 
-            qStr = 'job=' + job;
-            qStr += '&kernel=' + kernel;
-            qStr += '&git_branch=' + branch;
-            qStr += '&plan=' + plan;
+            qStr = URI.buildQuery({
+                'job': job,
+                'kernel': kernel,
+                'git_branch': branch,
+                'plan': plan,
+            });
 
             /* Number of test case regressions */
             batchOps.push({
@@ -374,9 +379,11 @@ require([
         var batchOps;
         var deferred;
 
-        qStr = 'job=' + gJob;
-        qStr += '&kernel=' + gKernel;
-        qStr += '&git_branch=' + gBranch;
+        qStr = URI.buildQuery({
+            'job': gJob,
+            'kernel': gKernel,
+            'git_branch': gBranch,
+        });
 
         batchOps = [];
 

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.1.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.1.js
@@ -18,6 +18,7 @@
  * along with this library; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 require([
     'jquery',
     'utils/init',
@@ -68,10 +69,10 @@ require([
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         describeNode.appendChild(buildsLink);
 
-        gitNode = document.createElement('a')
-        gitNode.appendChild(document.createTextNode(results.git_url))
-        gitNode.href = results.git_url
-        gitNode.title = "Git URL" /* ToDo: link to commit when possible */
+        gitNode = document.createElement('a');
+        gitNode.appendChild(document.createTextNode(results.git_url));
+        gitNode.href = results.git_url;
+        gitNode.title = "Git URL"; /* ToDo: link to commit when possible */
 
         createdOn = new Date(results.created_on.$date);
         dateNode = document.createElement('time');
@@ -86,7 +87,7 @@ require([
             document.getElementById('git-branch'),
             document.createTextNode(branch));
         html.replaceContent(
-            document.getElementById('git-describe'), describeNode)
+            document.getElementById('git-describe'), describeNode);
         html.replaceContent(
             document.getElementById('git-url'), gitNode);
         html.replaceContent(
@@ -147,7 +148,7 @@ require([
         }
 
         function _renderTestCount(data, type) {
-            return ttest.renderTestCount({data: data, type: type})
+            return ttest.renderTestCount({data: data, type: type});
         }
 
         function _renderPlanStatus(data, type) {
@@ -183,7 +184,7 @@ require([
                 className: 'pull-center',
                 render: _renderPlanStatus,
             },
-        ]
+        ];
 
         gPlansTable
             .data(results)
@@ -207,7 +208,7 @@ require([
                 document.createTextNode(data.result[0].count));
         }
 
-        response.result.forEach(parseBatchData)
+        response.result.forEach(parseBatchData);
     }
 
     function getBatchCount(results) {
@@ -264,13 +265,13 @@ require([
         }
 
         batchOps = [];
-        results.forEach(createBatchOp)
+        results.forEach(createBatchOp);
         deferred = request.post(
             '/_ajax/batch', JSON.stringify({batch: batchOps}));
 
         $.when(deferred)
             .fail(error.error, getBatchCountFailed)
-            .done(getBatchCountDone)
+            .done(getBatchCountDone);
     }
 
     function getBatchStatusDone(response) {
@@ -280,7 +281,7 @@ require([
             node.appendChild(ttest.statusNode(status));
         }
 
-        response.result.forEach(parseBatchData)
+        response.result.forEach(parseBatchData);
     }
 
     function getBatchStatusFailed() {
@@ -314,13 +315,13 @@ require([
         }
 
         batchOps = [];
-        results.forEach(createBatchOp)
+        results.forEach(createBatchOp);
         deferred = request.post(
             '/_ajax/batch', JSON.stringify({batch: batchOps}));
 
         $.when(deferred)
             .fail(error.error, getBatchStatusFailed)
-            .done(getBatchStatusDone)
+            .done(getBatchStatusDone);
     }
 
     function getPlansFailed() {
@@ -331,13 +332,13 @@ require([
     function getPlansDone(response) {
         if (response.result.length === 0) {
             getPlansFailed();
-            return
+            return;
         }
 
-        updateDetails(response.result[0])
-        updatePlansTable(response.result)
-        getBatchCount(response.result)
-        getBatchStatus(response.result)
+        updateDetails(response.result[0]);
+        updatePlansTable(response.result);
+        getBatchCount(response.result);
+        getBatchStatus(response.result);
     }
 
     function getPlans() {
@@ -362,7 +363,7 @@ require([
             ],
         };
 
-        deferred = request.get('/_ajax/test/group', data)
+        deferred = request.get('/_ajax/test/group', data);
         $.when(deferred)
             .fail(error.error, getPlansFailed)
             .done(getPlansDone);
@@ -377,7 +378,7 @@ require([
         qStr += '&kernel=' + gKernel;
         qStr += '&git_branch=' + gBranch;
 
-        batchOps = []
+        batchOps = [];
 
         /* Total number of test cases */
         batchOps.push({
@@ -420,7 +421,7 @@ require([
 
         $.when(deferred)
             .fail(error.error, chartCountFailed)
-            .done(updateChart)
+            .done(updateChart);
     }
 
     if (document.getElementById('job-name') !== null) {

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.1.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.1.js
@@ -203,13 +203,11 @@ require([
     }
 
     function getBatchCountDone(response) {
-        function parseBatchData(data) {
+        response.result.forEach(function(data) {
             html.replaceContent(
                 document.getElementById(data.operation_id),
                 document.createTextNode(data.result[0].count));
-        }
-
-        response.result.forEach(parseBatchData);
+        });
     }
 
     function getBatchCount(results) {
@@ -278,13 +276,11 @@ require([
     }
 
     function getBatchStatusDone(response) {
-        function parseBatchData(data) {
+        response.result.forEach(function(data) {
             var node = document.getElementById(data.operation_id);
             var status = (data.result[0].count == 0 ? "PASS" : "FAIL");
             node.appendChild(ttest.statusNode(status));
-        }
-
-        response.result.forEach(parseBatchData);
+        });
     }
 
     function getBatchStatusFailed() {

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.2.js
@@ -64,7 +64,7 @@ require([
         kernel = results.kernel;
 
         treeNode = html.tooltip();
-        treeNode.title = "Details for tree &#171;" + job + "&#187;"
+        treeNode.title = "Details for tree &#171;" + job + "&#187;";
         jobLink = document.createElement('a');
         jobLink.href = "/job/" + job + "/";
         jobLink.appendChild(html.tree());
@@ -113,7 +113,7 @@ require([
             document.getElementById('git-branch'),
             document.createTextNode(results.git_branch));
         html.replaceContent(
-            document.getElementById('git-describe'), describeNode)
+            document.getElementById('git-describe'), describeNode);
         html.replaceContent(
             document.getElementById('git-url'), gitNode);
         html.replaceContent(  /* ToDo: link to commit when possible */
@@ -241,7 +241,6 @@ require([
         data = [];
         results.forEach(function(item) {
             var status;
-            var measurements;
 
             if (item.status == 'PASS')
                 status = 'PASS';
@@ -307,7 +306,7 @@ require([
     function getTestsDone(response) {
         if (response.result.length === 0) {
             getTestsFailed();
-            return
+            return;
         }
 
         updateTestsTable(response.result);
@@ -330,7 +329,7 @@ require([
             sort: 'test_case_path',
         };
 
-        deferred = request.get('/_ajax/test/case', data)
+        deferred = request.get('/_ajax/test/case', data);
         $.when(deferred)
             .fail(error.error, getTestsFailed)
             .done(getTestsDone);
@@ -371,7 +370,7 @@ require([
             plan: results.name,
         });
 
-        batchOps = []
+        batchOps = [];
 
         batchOps.push({
             method: 'GET',
@@ -428,7 +427,7 @@ require([
     function getPlan() {
         if (!gPlanId) {
             getPlanFailed();
-            return
+            return;
         }
 
         $.when(request.get('/_ajax/test/group', {id: gPlanId}))


### PR DESCRIPTION
Some global syntax clean-up in the view-tests-*.js files:

* add missing semicolons
* remove some unused variables
* use `URI.buildQuery()`
* use inline functions in `.forEach()` iterations