### PR TITLE
T20701 Remove trailing whitespace in view-*.js and *.html files

### DIFF
--- a/app/dashboard/static/js/app/tables/test.js
+++ b/app/dashboard/static/js/app/tables/test.js
@@ -122,7 +122,7 @@ define([
     gTestTable.renderTree = function(tree, type, href) {
         return tcommon.renderTree(tree, type, href);
     };
-        
+
     gTestTable.getCountFail = function(idStart) {
         document.getElementById('cases-total-count-'+ idStart)
             .innerHTML ='&infin;';

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.2.1.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.2.1.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2017.4.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2017.4.js
@@ -3,9 +3,9 @@
  *
  * Copyright (C) 2020 Collabora Limited
  * Author: Alexandra Pereira <alexandra.pereira@collabora.com>
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -37,9 +37,9 @@ define([
         html,
         error,
         request,
-        urls, 
-        chart, 
-        table, 
+        urls,
+        chart,
+        table,
         ttest,
         URI) {
     'use strict';
@@ -137,7 +137,7 @@ define([
         aNode.appendChild(document.createTextNode(gitURL));
         aNode.insertAdjacentHTML('beforeend', '&nbsp;');
         aNode.appendChild(html.external());
-        
+
         html.replaceContent(document.getElementById('git-url'), aNode);
 
         // Git commit.
@@ -293,7 +293,7 @@ define([
         var batchOps;
         var deferred;
 
-        function createBatchOp(result) { 
+        function createBatchOp(result) {
             var qStr;
             var plan = result.name;
 
@@ -334,7 +334,7 @@ define([
         var deferred;
 
         function createBatchOp(result) {
-            
+
             var qStr;
             var plan = result.name;
 
@@ -407,7 +407,7 @@ define([
             getPlansFailed();
             return
         }
-    
+
         updateDetails(response.result[0]);
         updatePlansTable(response.result);
         getBatchCount(response.result);

--- a/app/dashboard/static/js/app/view-tests-all.2018.9.js
+++ b/app/dashboard/static/js/app/view-tests-all.2018.9.js
@@ -1,13 +1,13 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2020 Collabora Limited
  * Author: Alexandra Pereira <alexandra.pereira@collabora.com>
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  * Copyright (c) 2017 BayLibre, SAS.
  * Author: Loys Ollivier <lollivier@baylibre.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -100,7 +100,7 @@ require([
 
     function updateTestTable(response) {
         var columns;
-        
+
         function _renderTree(data, type) {
             return ttest.renderTree(
                 data, type, '/job/' + data + '/');
@@ -119,13 +119,13 @@ require([
 
         function _renderBranch(data, type, object) {
             var href;
-            
+
             href = '/job/';
             href += object.job;
             href += '/branch/';
             href += object.git_branch;
             href += '/';
-            
+
             return jobt.renderKernel(data, type, href);
         }
 
@@ -282,5 +282,4 @@ require([
 
     setTimeout(init.hotkeys, 50);
     setTimeout(init.tooltip, 50);
-
 });

--- a/app/dashboard/templates/socs-soc-job-kernel.html
+++ b/app/dashboard/templates/socs-soc-job-kernel.html
@@ -72,7 +72,7 @@
         </div>
     </div>
 </div>
-<div class="row">   
+<div class="row">
     <div class="page-header">
         <h3>Available Test Plans</h3>
     </div>


### PR DESCRIPTION
Remove all trailing whitespace introduced since 2020.01 in *.js and
*.html files.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>