### PR TITLE
Fix builds view initial state to show failed builds only

### DIFF
--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.2.1.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.2.1.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -228,7 +228,7 @@ require([
         var warnErrTooltip;
         var warningString;
         var warningsCount;
-        var docFrag;
+        var accordion;
 
         hasFailed = false;
         hasSuccess = false;
@@ -296,7 +296,7 @@ require([
 
             translatedURI = u.createFileServerURL(fileServerURL, result);
 
-            panelNode = docFrag.appendChild(document.createElement('div'));
+            panelNode = accordion.appendChild(document.createElement('div'));
 
             // Set the data-index attribute to filter the results.
             panelNode.setAttribute('data-index', _createDataIndex(result));
@@ -669,10 +669,10 @@ require([
                 document.getElementById('accordion-container'),
                 html.errorDiv('No data available'));
         } else {
-            docFrag = document.createDocumentFragment();
+            accordion = document.getElementById('accordion');
+            while (accordion.firstChild)
+                accordion.removeChild(accordion.firstChild);
             results.forEach(_parseResult);
-            // Append everything at the end.
-            html.replaceContent(document.getElementById('accordion'), docFrag);
 
             document
                 .getElementById('all-btn').removeAttribute('disabled');
@@ -691,19 +691,17 @@ require([
                     .getElementById('unknown-btn').removeAttribute('disabled');
             }
 
-            setTimeout(function() {
-                if (!loadSavedSession()) {
-                    if (hasFailed) {
-                        showFailedOnly();
-                    } else {
-                        html.addClass(
-                            document.getElementById('all-btn'), 'active');
-                    }
+            if (!loadSavedSession()) {
+                if (hasFailed) {
+                    showFailedOnly();
+                } else {
+                    html.addClass(
+                        document.getElementById('all-btn'), 'active');
                 }
-            }, 0);
+            }
 
             // Bind buttons to the correct function.
-            setTimeout(bindDetailButtons, 0);
+            bindDetailButtons();
         }
     }
 


### PR DESCRIPTION
The builds view was implemented using a document fragment to create
the list of builds and then replace the "accordion" element contents
with that fragment.  There appears to be a delay for that to take
effect, so updating the buttons status and hiding the related builds
(say, hiding passing builds when the "Failed" button is selected) may
not be possible if the fragment is not yet part of the document.

To avoid this issue, use the same approach as the tests view by
directly appending all the elements to the "accordion" div rather than
using a document fragment.  We can also remove the unnecessary timeout
clauses around the functions that set the buttons state as a result.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>