### PR TITLE
T20698 Replace boots table with test runs on builds-id view

### DIFF
--- a/app/dashboard/templates/builds-id.html
+++ b/app/dashboard/templates/builds-id.html
@@ -230,19 +230,19 @@
 </div>
 <div class="row">
     <div class="page-header">
-        <h3 id="boot-reports">Boot Reports</h3>
+        <h3 id="test-results">Test Results</h3>
     </div>
     <div id="table-loading" class="pull-center">
         <small>
-            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;searching boot data&hellip;
+            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;searching test data&hellip;
         </small>
     </div>
 {%- if is_mobile %}
-    <div class="table-responsive" id="boots-table-div">
+    <div class="table-responsive" id="tests-table-div">
 {%- else %}
-    <div class="table" id="boots-table-div">
+    <div class="table" id="tests-table-div">
 {%- endif %}
-        <table class="table table-hover table-striped table-condensed clickable-table big-table" id="bootstable">
+        <table class="table table-hover table-striped table-condensed clickable-table big-table" id="tests-table">
         </table>
     </div>
 </div>


### PR DESCRIPTION
Rather than showing a table with deprecated boot results for a given
kernel build, show the test plan runs with links to the detailed views
containing a list of all the test cases.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>