### PR TITLE
T21039 Replace remaining Boots links with Tests on builds views

### DIFF
--- a/app/dashboard/static/js/app/view-builds-id.2017.4.js
+++ b/app/dashboard/static/js/app/view-builds-id.2017.4.js
@@ -461,13 +461,13 @@ require([
             spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
             tooltipNode = spanNode.appendChild(html.tooltip());
-            str = 'Boot reports for tree';
+            str = 'Test reports for tree';
             str += '&nbsp;';
             str += job;
             tooltipNode.setAttribute('title', str);
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
-            str = '/boot/all/job/';
+            str = '/job/';
             str += job;
             str += '/';
             aNode.setAttribute('href', str);
@@ -483,43 +483,25 @@ require([
             docFrag = document.createDocumentFragment();
             spanNode = docFrag.appendChild(document.createElement('span'));
 
+            // Describe.
             tooltipNode = spanNode.appendChild(html.tooltip());
-            str = 'Build details for';
-            str +='&nbsp;';
-            str += job;
-            str += '&nbsp;&ndash;&nbsp;';
-            str += kernel;
-            str += '&nbsp;(';
-            str += branch;
-            str += ')';
-            tooltipNode.setAttribute('title', str);
-
-            aNode = tooltipNode.appendChild(document.createElement('a'));
-            str = '/build/';
-            str += job;
-            str += '/branch/';
-            str += branch;
-            str += '/kernel/';
-            str += kernel;
-            str += '/';
-            aNode.setAttribute('href', str);
-            aNode.appendChild(document.createTextNode(kernel));
+            tooltipNode.title =
+                "Build reports for &#171;" + job + "&#187; - " + kernel;
+            aNode = document.createElement('a');
+            aNode.href = "/build/" + job + "/kernel/" + kernel;
+            aNode.appendChild(html.build());
+            tooltipNode.appendChild(document.createTextNode(kernel));
+            tooltipNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+            tooltipNode.appendChild(aNode);
 
             spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
             tooltipNode = spanNode.appendChild(html.tooltip());
-            str = 'Boot reports for';
-            str += '&nbsp;';
-            str += job;
-            str += '&nbsp;&ndash;&nbsp;';
-            str += kernel;
-            str += '&nbsp;(';
-            str += branch;
-            str += ')';
-            tooltipNode.setAttribute('title', str);
+            tooltipNode.title =
+               "Test reports for &#171;" + job + "&#187; - " + kernel;
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
-            str = '/boot/all/job/';
+            str = '/test/job/';
             str += job;
             str += '/branch/';
             str += branch;
@@ -644,33 +626,6 @@ require([
             docFrag = document.createDocumentFragment();
             spanNode = docFrag.appendChild(document.createElement('span'));
             spanNode.appendChild(document.createTextNode(defconfigFull));
-
-            spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-            tooltipNode = spanNode.appendChild(html.tooltip());
-            str = 'Boot reports for';
-            str += '&nbsp;';
-            str += job;
-            str += '&nbsp;&ndash;&nbsp;';
-            str += kernel;
-            str += '&nbsp;(';
-            str += branch;
-            str += '&nbsp;&ndash;&nbsp';
-            str += defconfigFull;
-            str += ')';
-            tooltipNode.setAttribute('title', str);
-
-            aNode = tooltipNode.appendChild(document.createElement('a'));
-            str = '/boot/all/job/';
-            str += job;
-            str += '/branch/';
-            str += branch;
-            str += '/kernel/';
-            str += kernel;
-            str += '/defconfig/';
-            str += defconfigFull;
-            str += '/';
-            aNode.setAttribute('href', str);
-            aNode.appendChild(html.boot());
 
             html.replaceContent(
                 document.getElementById('build-defconfig'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.2.1.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.2.1.js
@@ -803,11 +803,11 @@ require([
 
             tooltipNode = spanNode.appendChild(html.tooltip());
             tooltipNode.setAttribute(
-                'title', 'Boot reports for ' + job);
+                'title', 'Test reports for ' + job);
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
             aNode.setAttribute(
-                'href', u.createPathHref(['/boot/all/job/', job, '/']));
+                'href', u.createPathHref(['/job/', job, '/']));
             aNode.appendChild(html.boot());
 
             html.replaceContent(document.getElementById('tree'), docFrag);
@@ -829,7 +829,7 @@ require([
             tooltipNode = spanNode.appendChild(html.tooltip());
             tooltipNode.setAttribute(
                 'title',
-                'Boot reports for ' + job + '&nbsp;&ndash;&nbsp;' +
+                'Test reports for ' + job + '&nbsp;&ndash;&nbsp;' +
                 kernel +
                 '&nbsp;(' + branch + ')'
             );
@@ -837,7 +837,7 @@ require([
             aNode.setAttribute(
                 'href',
                 u.createPathHref([
-                    '/boot/all/job/',
+                    '/test/job/',
                     job,
                     'branch',
                     branch,

--- a/app/dashboard/static/js/app/view-builds-job-kernel.2017.4.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel.2017.4.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -176,6 +176,7 @@ require([
         var aNode;
         var docFrag;
         var job;
+        var branch;
         var kernel;
         var results;
         var spanNode;
@@ -187,6 +188,7 @@ require([
         } else {
             results = results[0];
             job = results.job;
+            branch = results.git_branch;
             kernel = results.kernel;
 
             // The kernel name in the title.
@@ -209,11 +211,11 @@ require([
 
             tooltipNode = spanNode.appendChild(html.tooltip());
             tooltipNode.setAttribute(
-                'title', 'Boot reports for ' + job);
+                'title', 'Test reports for ' + job);
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
             aNode.setAttribute(
-                'href', u.createPathHref(['/boot/all/job/', job, '/']));
+                'href', u.createPathHref(['/job/', job, '/']));
             aNode.appendChild(html.boot());
 
             html.replaceContent(document.getElementById('tree'), docFrag);
@@ -230,14 +232,16 @@ require([
             tooltipNode = spanNode.appendChild(html.tooltip());
             tooltipNode.setAttribute(
                 'title',
-                'Boot reports for ' + job + '&nbsp;&ndash;&nbsp;' + kernel
+                'Test reports for ' + job + '&nbsp;&ndash;&nbsp;' + kernel
             );
             aNode = tooltipNode.appendChild(document.createElement('a'));
             aNode.setAttribute(
                 'href',
                 u.createPathHref([
-                    '/boot/all/job/',
+                    '/test/job/',
                     job,
+                    'branch',
+                    branch,
                     'kernel',
                     kernel,
                     '/'


### PR DESCRIPTION
Replace links to Boots views in the details sections of the builds
views with corresponding links to Tests views when possible or drop
the links otherwise.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>