### PR TITLE
T21035 stop using toCustomISODateTime

### DIFF
--- a/app/dashboard/static/js/app/tables/common.js
+++ b/app/dashboard/static/js/app/tables/common.js
@@ -278,9 +278,6 @@ define([
             if (type === 'display') {
                 node = _dateNode(date).firstElementChild;
                 rendered = node.outerHTML;
-            } if (type === 'sort') {
-                created = new Date(date.$date);
-                rendered = created.toCustomISODateTime();
             } else {
                 created = new Date(date.$date);
                 rendered = created.toCustomISODate();


### PR DESCRIPTION
`toCustomISODateTime()` usage was breaking sort by date on
Firefox, now the code will just use `toCustomISODate()`.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>