### PR TITLE
T21347 update status column on table test

### DIFF
--- a/app/dashboard/static/js/app/view-tests-all.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-all.2020.5.js
@@ -198,6 +198,16 @@ require([
             var href;
             var nodeId;
 
+            href = '/test/job/';
+            href += object.job;
+            href += '/branch/';
+            href += object.git_branch;
+            href += '/kernel/';
+            href += object.kernel;
+            href += '/plan/';
+            href += object.name;
+            href += '/';
+
             nodeId = data;
             var testDiv = ttest.renderTestCount({
                 data: nodeId,
@@ -205,14 +215,16 @@ require([
                 href: href
             });
 
-            var node = $(testDiv)[0];
-            node.childNodes.forEach(function(span){
+            var div = $(testDiv)[0];
+            var spans = div.getElementsByTagName('span');
+
+            Array.from(spans).forEach(function(span){
                 if (gTestCount[span.id] != undefined){
                     span.removeChild(span.firstElementChild);
                     span.appendChild(document.createTextNode(gTestCount[span.id]));
                 }
             })
-            return node.outerHTML;
+            return div.outerHTML;
         }
 
         if (response.length === 0) {
@@ -250,13 +262,6 @@ require([
                     className: 'plan-column',
                 },
                 {
-                    data: 'created_on',
-                    type: 'datetime',
-                    title: 'Date',
-                    className: 'date-column',
-                    render: ttest.renderDate
-                },
-                {
                     data: '_id.$oid',
                     title: _testColumnTitle(),
                     type: 'string',
@@ -264,13 +269,20 @@ require([
                     orderable: false,
                     className: 'test-count pull-center',
                     render: _renderTestCount
+                },
+                {
+                    data: 'created_on',
+                    type: 'datetime',
+                    title: 'Date',
+                    className: 'date-column',
+                    render: ttest.renderDate
                 }
             ];
 
             gTestsTable
                 .data(response)
                 .columns(columns)
-                .order([4, 'desc'])
+                .order([5, 'desc'])
                 .languageLengthMenu('Tests per page')
                 .rowURL('/test/job/%(job)s/branch/%(git_branch)s/kernel/%(kernel)s/plan/%(name)s/')
                 .rowURLElements(['job', 'git_branch', 'kernel', 'name'])

--- a/app/dashboard/static/js/app/view-tests-all.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-all.2020.5.js
@@ -43,7 +43,7 @@ require([
     var gSearchFilter;
     var gPageLen;
     var gTestsTable;
-    var gTestStatus = {};
+    var gTestCount = {};
 
     setTimeout(function() {
         document.getElementById('li-test').setAttribute('class', 'active');
@@ -51,12 +51,13 @@ require([
 
     gDateRange = appconst.MAX_DATE_RANGE;
 
-    function getBatchTestStatusDone(results) {
+    function getBatchTestCountDone(results) {
         var batchData;
 
         batchData = results.result;
 
         function parseBatchData(data) {
+            gTestCount[data.operation_id] = data.result[0].count;
             html.replaceContent(
                 document.getElementById(data.operation_id),
                 document.createTextNode(data.result[0].count));
@@ -67,11 +68,11 @@ require([
         }
     }
 
-    function getBatchTestStatusFailed() {
-        console.log("getBatchTestStatusFailed()");
+    function getBatchTestCountFailed() {
+        console.log("getBatchTestCountFailed()");
     }
 
-    function getBatchTestStatus(results) {
+    function getBatchTestCount(results) {
         var batchOps;
         var deferred;
         function createBatchOp(result) {
@@ -140,8 +141,8 @@ require([
             '/_ajax/batch', JSON.stringify({batch: batchOps}));
 
         $.when(deferred)
-            .fail(error.error, getBatchTestStatusFailed)
-            .done(getBatchTestStatusDone)
+            .fail(error.error, getBatchTestCountFailed)
+            .done(getBatchTestCountDone)
     }
 
     function updateTestTable(response) {
@@ -198,11 +199,20 @@ require([
             var nodeId;
 
             nodeId = data;
-            return ttest.renderTestCount({
+            var testDiv = ttest.renderTestCount({
                 data: nodeId,
                 type: type,
                 href: href
             });
+
+            var node = $(testDiv)[0];
+            node.childNodes.forEach(function(span){
+                if (gTestCount[span.id] != undefined){
+                    span.removeChild(span.firstElementChild);
+                    span.appendChild(document.createTextNode(gTestCount[span.id]));
+                }
+            })
+            return node.outerHTML;
         }
 
         if (response.length === 0) {
@@ -276,7 +286,7 @@ require([
 
     function getTestsDone(response){
         updateTestTable(response);
-        getBatchTestStatus(response);
+        getBatchTestCount(response);
     }
 
     function getTestsParse(response) {


### PR DESCRIPTION
Avoid showing unknown on status column while loading test results and
while it is loading show spinning animations waiting for data to arrive.
The data used to show status was also updated to show test count for
each combation of plan and group.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>