### PR TITLE
T21524 Hide boot results and update deprecation banner

### DIFF
--- a/app/dashboard/templates/boots-all.html
+++ b/app/dashboard/templates/boots-all.html
@@ -1,4 +1,4 @@
-{% extends "base-all.html" %}
+{% extends "base.html" %}
 {%- block content %}
 {%- include "boots-deprecation.html" %}
 {{ super() }}

--- a/app/dashboard/templates/boots-deprecation.html
+++ b/app/dashboard/templates/boots-deprecation.html
@@ -1,14 +1,11 @@
 <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 boot-deprecation">
-      <h2 align="center">
-        &#x26A0;&nbsp;Boot tests are now deprecated&nbsp;&#x26A0;
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 boot-deprecation" align="center">
+      <h2>
+        &#x26A0;&nbsp;Boot tests have now been deprecated&nbsp;&#x26A0;
       </h2>
       <p>
         As kernelci.org is expanding its functional testing capabilities, the
-        concept of boot testing is now deprecated.  Boot results are scheduled
-        to be dropped on <span style="font-weight: bold">5th June 2020</span>.
-        The full schedule for boot tests deprecation is available
-        on <a href="https://github.com/kernelci/kernelci-backend/issues/238">GitHub</a>.
+        concept of boot testing has now been deprecated.
       </p>
       <p>
         The new equivalent is the <span style="font-weight:
@@ -16,9 +13,9 @@
         including <a href="https://github.com/kernelci/bootrr">bootrr</a>.
       </p>
       <p>
-        And of course, a lot of functional test suites are in the process of
-        being added: kselftest, KUnit, LTP, xfstests, i-g-t, v4l2-compliance,
-        suspend/resume...  Stay tuned!
+        Baseline results can be found using this filter in
+        the <a href="https://kernelci.org/test/">Tests</a>
+        tab: <a href="https://kernelci.org/test/?baseline">https://kernelci.org/test/?baseline</a>
       </p>
     </div>
 </div>


### PR DESCRIPTION
Now that boot results have been fully deprecated, hide the boot
results in the Boots tab and update the deprecation banner with a link
to the baseline results filter in the Tests tab.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>