### PR TITLE
T21524 Remove table with distinct boards in socs-soc view

### DIFF
--- a/app/dashboard/static/js/app/view-socs-soc.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc.2020.5.js
@@ -30,7 +30,6 @@ require([
 ], function($, init, format, r, e, appconst, html, tsoc, table) {
     'use strict';
     var gBatchCountMissing,
-        gBoardsTable,
         gDateRange,
         gJobsTable,
         gPageLen,
@@ -45,68 +44,6 @@ require([
     gPageLen = null;
     gSearchFilter = null;
     gTableCount = {};
-
-    function getDistinctBoardsTable(response) {
-        var columns,
-            results,
-            tableResults;
-
-        /**
-         * Internally used to remap an array of strings into an array of
-         * objects whose key is 'board'.
-         *
-         * @param {string} element: The element from the array.
-         * @return {object} An object with key 'board' and value the passed
-         * one.
-        **/
-        function _remapResults(element) {
-            return {board: element};
-        }
-
-        // Internal wrapper to provide the href and title.
-        function _boardDetails(data, type) {
-            return tsoc.renderDetails(
-                '/boot/' + data + '/', type, 'View boot reports');
-        }
-
-        results = response.result;
-        if (results.length > 0) {
-            columns = [
-                {
-                    data: 'board',
-                    title: 'Device type'
-                },
-                {
-                    data: 'board',
-                    title: '',
-                    orderable: false,
-                    searchable: false,
-                    className: 'select-column pull-center',
-                    render: _boardDetails
-                }
-            ];
-
-            // Remap the distinct results into an array of objets.
-            tableResults = results.map(_remapResults);
-
-            gBoardsTable
-                .rowURL('/boot/%(board)s/')
-                .rowURLElements(['board'])
-                .data(tableResults)
-                .columns(columns)
-                .lengthMenu([5, 10, 25, 50])
-                .languageLengthMenu('device types per page')
-                .order([0, 'asc'])
-                .draw();
-
-        } else {
-            html.removeElement(
-                document.getElementById('boards-table-loading'));
-            html.replaceContent(
-                document.getElementById('boards-table-div'),
-                html.errorDiv('No data found.'));
-        }
-    }
 
     function getDistinctBoardsFail() {
         html.replaceContentHTML(
@@ -156,7 +93,7 @@ require([
 
         $.when(deferred)
             .fail(e.error, getDistinctBoardsFail)
-            .done(getDistinctBoardsCount, getDistinctBoardsTable);
+            .done(getDistinctBoardsCount);
     }
 
     function updateOrStageCount(elementId, count) {
@@ -455,12 +392,6 @@ require([
         tableId: 'jobs-table',
         tableDivId: 'jobs-table-div',
         tableLoadingDivId: 'jobs-table-loading'
-    });
-
-    gBoardsTable = table({
-        tableId: 'boards-table',
-        tableDivId: 'boards-table-div',
-        tableLoadingDivId: 'boards-table-loading'
     });
 
     getDetails();

--- a/app/dashboard/templates/socs-soc.html
+++ b/app/dashboard/templates/socs-soc.html
@@ -35,27 +35,6 @@
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
         <div class="page-header">
-            <h3>Device Types</h3>
-        </div>
-        <div id="boards-table-loading" class="pull-center">
-            <small>
-                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-                &nbsp;retrieving board data&hellip;
-            </small>
-        </div>
-    {%- if is_mobile %}
-        <div class="table-responsive" id="boards-table-div">
-    {%- else %}
-        <div class="table" id="boards-table-div">
-    {%- endif %}
-            <table class="table table-hover table-striped table-condensed clickable-table big-table" id="boards-table">
-            </table>
-        </div>
-    </div>
-</div>
-<div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-        <div class="page-header">
             <h3>Available Branches</h3>
         </div>
         <div id="jobs-table-loading" class="pull-center">


### PR DESCRIPTION
Now that boot views are deprecated, remote the table with list of
distinct device types in the SoC view as there is no equivalent tests
view with results for a single board.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>