### PR TITLE
T21524 Remove boot results from home page

### DIFF
--- a/app/dashboard/templates/index.html
+++ b/app/dashboard/templates/index.html
@@ -103,12 +103,12 @@
                     </span>
                 </li>
                 <li>
-                    <a class="btn btn-default" href="/boot/" role="button">
-                        <i class="fa fa-hdd-o fa-lg"></i>
+                    <a class="btn btn-default" href="/test/" role="button">
+                        <i class="fa fa-stethoscope fa-lg"></i>
                     </a>
                     &nbsp;
                     <span class="selection-label">
-                        View latest boot reports
+                        View latest test reports
                     </span>
                 </li>
                 <li>
@@ -118,15 +118,6 @@
                     &nbsp;
                     <span class="selection-label">
                         View SoCs being tested
-                    </span>
-                </li>
-                <li>
-                    <a class="btn btn-default" href="/test/" role="button">
-                        <i class="fa fa-stethoscope fa-lg"></i>
-                    </a>
-                    &nbsp;
-                    <span class="selection-label">
-                        View latest test reports
                     </span>
                 </li>
                 <li>


### PR DESCRIPTION
Remove the direct link to the boots tab from the home page since it
has now been deprecated.  Also move the direct link to the tests tab
up in the list.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>