### PR TITLE
T21349 align tooltips on test views fixup

### DIFF
--- a/app/dashboard/static/js/app/utils/html.js
+++ b/app/dashboard/static/js/app/utils/html.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -127,6 +127,19 @@ define([
         return frag;
     };
 
+    html.test = function (extraClass) {
+        var frag;
+        var iNode;
+        var spanNode;
+
+        frag = document.createDocumentFragment();
+
+        iNode = frag.appendChild(document.createElement('i'));
+        iNode.className = 'fa fa-stethoscope';
+
+        return frag;
+    };
+
     html.soc = function() {
         var frag;
         var iNode;
@@ -223,24 +236,6 @@ define([
         }
         iNode = spanNode.appendChild(document.createElement('i'));
         iNode.className = 'fa fa-check';
-
-        return frag;
-    };
-
-    html.stethoscope = function (extraClass) {
-        var frag;
-        var iNode;
-        var spanNode;
-
-        frag = document.createDocumentFragment();
-
-        spanNode = frag.appendChild(document.createElement('span'));
-        spanNode.className = 'label label-success label-status';
-        if (extraClass && extraClass.trim().length > 0) {
-            spanNode.className += ' ' + extraClass;
-        }
-        iNode = spanNode.appendChild(document.createElement('i'));
-        iNode.className = 'fa fa-stethoscope';
 
         return frag;
     };

--- a/app/dashboard/static/js/app/utils/html.js
+++ b/app/dashboard/static/js/app/utils/html.js
@@ -227,6 +227,24 @@ define([
         return frag;
     };
 
+    html.stethoscope = function (extraClass) {
+        var frag;
+        var iNode;
+        var spanNode;
+
+        frag = document.createDocumentFragment();
+
+        spanNode = frag.appendChild(document.createElement('span'));
+        spanNode.className = 'label label-success label-status';
+        if (extraClass && extraClass.trim().length > 0) {
+            spanNode.className += ' ' + extraClass;
+        }
+        iNode = spanNode.appendChild(document.createElement('i'));
+        iNode.className = 'fa fa-stethoscope';
+
+        return frag;
+    };
+
     html.unknown = function(extraClass) {
         var frag;
         var iNode;

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -503,6 +503,8 @@ require([
         var translatedUri;
         var txtSize;
         var vmlinuxFileSize;
+        var branchNode;
+        var branchLink;
 
         results = response.result;
 
@@ -618,9 +620,18 @@ require([
             html.replaceContent(document.getElementById('tree'), docFrag);
 
             // Branch.
+            branchNode = html.tooltip();
+            branchNode.title =
+                "Branch reports for &#171;" + job + "&#187; - " + branch;
+            branchLink = document.createElement('a');
+            branchLink.href = "/job/" + job + "/branch/" + branch;
+            branchLink.appendChild(html.tree());
+            branchNode.appendChild(document.createTextNode(branch));
+            branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+            branchNode.appendChild(branchLink);
+
             html.replaceContent(
-                document.getElementById('git-branch'),
-                document.createTextNode(branch));
+                document.getElementById('git-branch'), branchNode);
 
             docFrag = document.createDocumentFragment();
             spanNode = docFrag.appendChild(document.createElement('span'));

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -639,7 +639,8 @@ require([
             tooltipNode.title =
                 "Build reports for &#171;" + job + "&#187; - " + kernel;
             aNode = document.createElement('a');
-            aNode.href = "/build/" + job + "/kernel/" + kernel;
+            aNode.href =
+                "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
             aNode.appendChild(html.build());
             tooltipNode.appendChild(document.createTextNode(kernel));
             tooltipNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -609,17 +609,11 @@ require([
             spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
             tooltipNode = spanNode.appendChild(html.tooltip());
-            str = 'Test reports for ';
-            str += '&nbsp;';
-            str += job;
-            tooltipNode.setAttribute('title', str);
+            tooltipNode.title = "All results for tree &#171;" + job + "&#187;"
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
-            str = '/job/';
-            str += job;
-            str += '/';
-            aNode.setAttribute('href', str);
-            aNode.appendChild(html.boot());
+            aNode.href = "/job/" + job + "/";
+            aNode.appendChild(html.tree());
 
             html.replaceContent(document.getElementById('tree'), docFrag);
 

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -653,15 +653,10 @@ require([
                "Test reports for &#171;" + job + "&#187; - " + kernel;
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
-            str = '/test/job/';
-            str += job;
-            str += '/branch/';
-            str += branch;
-            str += '/kernel/';
-            str += kernel;
-            str += '/';
-            aNode.setAttribute('href', str);
-            aNode.appendChild(html.stethoscope());
+            aNode.href =
+                "/test/job/" + job + "/branch/" + branch +
+                "/kernel/" + kernel + "/";
+            aNode.appendChild(html.test());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -503,8 +503,6 @@ require([
         var translatedUri;
         var txtSize;
         var vmlinuxFileSize;
-        var defconfigLink;
-        var defconfigNode;
 
         results = response.result;
 
@@ -777,18 +775,12 @@ require([
             }
 
             // Defconfig.
-            defconfigNode = html.tooltip();
-            defconfigNode.title =
-                "defconfig reports for &#171;" + job + "&#187; - " + defconfigFull;
-            defconfigLink = document.createElement('a');
-            defconfigLink.href = "/build/id/" + results._id.$oid;
-            defconfigLink.appendChild(html.build());
-            defconfigNode.appendChild(document.createTextNode(defconfigFull));
-            defconfigNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-            defconfigNode.appendChild(defconfigLink);
+            docFrag = document.createDocumentFragment();
+            spanNode = docFrag.appendChild(document.createElement('span'));
+            spanNode.appendChild(document.createTextNode(defconfigFull));
 
             html.replaceContent(
-                document.getElementById('build-defconfig'), defconfigNode);
+                document.getElementById('build-defconfig'), docFrag);
 
             // Date.
             docFrag = document.createDocumentFragment();

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -603,19 +603,13 @@ require([
             spanNode = docFrag.appendChild(document.createElement('span'));
 
             tooltipNode = spanNode.appendChild(html.tooltip());
-            tooltipNode.setAttribute('title', 'Details for tree&nbsp;' + job);
 
-            aNode = tooltipNode.appendChild(document.createElement('a'));
-            str = '/job/';
-            str += job;
-            str += '/';
-            aNode.setAttribute('href', str);
-            aNode.appendChild(document.createTextNode(job));
+            aNode = tooltipNode.appendChild(document.createTextNode(job));
 
             spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
             tooltipNode = spanNode.appendChild(html.tooltip());
-            str = 'Test reports for tree';
+            str = 'Test reports for ';
             str += '&nbsp;';
             str += job;
             tooltipNode.setAttribute('title', str);

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -661,7 +661,7 @@ require([
             str += kernel;
             str += '/';
             aNode.setAttribute('href', str);
-            aNode.appendChild(html.boot());
+            aNode.appendChild(html.stethoscope());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -503,6 +503,8 @@ require([
         var translatedUri;
         var txtSize;
         var vmlinuxFileSize;
+        var defconfigLink;
+        var defconfigNode;
 
         results = response.result;
 
@@ -775,12 +777,18 @@ require([
             }
 
             // Defconfig.
-            docFrag = document.createDocumentFragment();
-            spanNode = docFrag.appendChild(document.createElement('span'));
-            spanNode.appendChild(document.createTextNode(defconfigFull));
+            defconfigNode = html.tooltip();
+            defconfigNode.title =
+                "defconfig reports for &#171;" + job + "&#187; - " + defconfigFull;
+            defconfigLink = document.createElement('a');
+            defconfigLink.href = "/build/id/" + results._id.$oid;
+            defconfigLink.appendChild(html.build());
+            defconfigNode.appendChild(document.createTextNode(defconfigFull));
+            defconfigNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+            defconfigNode.appendChild(defconfigLink);
 
             html.replaceContent(
-                document.getElementById('build-defconfig'), docFrag);
+                document.getElementById('build-defconfig'), defconfigNode);
 
             // Date.
             docFrag = document.createDocumentFragment();

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -636,8 +636,7 @@ require([
 
             // Describe.
             tooltipNode = spanNode.appendChild(html.tooltip());
-            tooltipNode.title =
-                "Build reports for &#171;" + job + "&#187; - " + kernel;
+            tooltipNode.title = "Build results for &#171;" + kernel + "&#187;";
             aNode = document.createElement('a');
             aNode.href =
                 "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
@@ -649,8 +648,7 @@ require([
             spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
             tooltipNode = spanNode.appendChild(html.tooltip());
-            tooltipNode.title =
-               "Test reports for &#171;" + job + "&#187; - " + kernel;
+            tooltipNode.title = "Test results for &#171;" + kernel + "&#187;";
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
             aNode.href =

--- a/app/dashboard/static/js/app/view-builds-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.5.js
@@ -503,8 +503,6 @@ require([
         var translatedUri;
         var txtSize;
         var vmlinuxFileSize;
-        var branchNode;
-        var branchLink;
 
         results = response.result;
 
@@ -620,18 +618,18 @@ require([
             html.replaceContent(document.getElementById('tree'), docFrag);
 
             // Branch.
-            branchNode = html.tooltip();
-            branchNode.title =
-                "Branch reports for &#171;" + job + "&#187; - " + branch;
-            branchLink = document.createElement('a');
-            branchLink.href = "/job/" + job + "/branch/" + branch;
-            branchLink.appendChild(html.tree());
-            branchNode.appendChild(document.createTextNode(branch));
-            branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-            branchNode.appendChild(branchLink);
+            tooltipNode = html.tooltip();
+            tooltipNode.title =
+                "All results for branch &#171;" + branch + "&#187;";
+            aNode = document.createElement('a');
+            aNode.href = "/job/" + job + "/branch/" + branch;
+            aNode.appendChild(html.tree());
+            tooltipNode.appendChild(document.createTextNode(branch));
+            tooltipNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+            tooltipNode.appendChild(aNode);
 
             html.replaceContent(
-                document.getElementById('git-branch'), branchNode);
+                document.getElementById('git-branch'), tooltipNode);
 
             docFrag = document.createDocumentFragment();
             spanNode = docFrag.appendChild(document.createElement('span'));

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -852,8 +852,7 @@ require([
             spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
             tooltipNode = spanNode.appendChild(html.tooltip());
-            tooltipNode.title =
-                "Test reports for &#171;" + job + "&#187; - " + kernel;
+            tooltipNode.title = "Test results for &#171;" + kernel + "&#187;";
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
             aNode.href =

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -791,21 +791,18 @@ require([
             // Tree.
             docFrag = document.createDocumentFragment();
             spanNode = docFrag.appendChild(document.createElement('span'));
-            tooltipNode = spanNode.appendChild(html.tooltip());
-
-            aNode = tooltipNode.appendChild(document.createTextNode(job));
+            spanNode.appendChild(document.createTextNode(job));
 
             spanNode.insertAdjacentHTML(
                 'beforeend', '&nbsp;&mdash;&nbsp;');
 
             tooltipNode = spanNode.appendChild(html.tooltip());
-            tooltipNode.setAttribute(
-                'title', 'Test reports for ' + job);
+            tooltipNode.title = "All results for tree &#171;" + job + "&#187;"
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
             aNode.setAttribute(
                 'href', u.createPathHref(['/job/', job, '/']));
-            aNode.appendChild(html.boot());
+            aNode.appendChild(html.tree());
 
             html.replaceContent(document.getElementById('tree'), docFrag);
 

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -831,7 +831,7 @@ require([
             tooltipNode = spanNode.appendChild(html.tooltip());
             tooltipNode.setAttribute(
                 'title',
-                'Test reports for ' + job + '&nbsp;&ndash;&nbsp;' +
+                'Build reports for ' + job + '&nbsp;&ndash;&nbsp;' +
                 kernel +
                 '&nbsp;(' + branch + ')'
             );
@@ -839,7 +839,7 @@ require([
             aNode.setAttribute(
                 'href',
                 u.createPathHref([
-                    '/test/job/',
+                    '/build/',
                     job,
                     'branch',
                     branch,
@@ -847,7 +847,7 @@ require([
                     kernel,
                     '/'
                 ]));
-            aNode.appendChild(html.boot());
+            aNode.appendChild(html.build());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -824,31 +824,6 @@ require([
             spanNode = docFrag.appendChild(document.createElement('span'));
 
             spanNode.appendChild(document.createTextNode(kernel));
-
-            spanNode.insertAdjacentHTML(
-                'beforeend', '&nbsp;&mdash;&nbsp;');
-
-            tooltipNode = spanNode.appendChild(html.tooltip());
-            tooltipNode.setAttribute(
-                'title',
-                'Build reports for ' + job + '&nbsp;&ndash;&nbsp;' +
-                kernel +
-                '&nbsp;(' + branch + ')'
-            );
-            aNode = tooltipNode.appendChild(document.createElement('a'));
-            aNode.setAttribute(
-                'href',
-                u.createPathHref([
-                    '/build/',
-                    job,
-                    'branch',
-                    branch,
-                    'kernel',
-                    kernel,
-                    '/'
-                ]));
-            aNode.appendChild(html.build());
-
             spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
             tooltipNode = spanNode.appendChild(html.tooltip());

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -792,11 +792,8 @@ require([
             docFrag = document.createDocumentFragment();
             spanNode = docFrag.appendChild(document.createElement('span'));
             tooltipNode = spanNode.appendChild(html.tooltip());
-            tooltipNode.setAttribute('title', 'Details for tree ' + job);
 
-            aNode = tooltipNode.appendChild(document.createElement('a'));
-            aNode.setAttribute('href', u.createPathHref(['/job/', job, '/']));
-            aNode.appendChild(document.createTextNode(job));
+            aNode = tooltipNode.appendChild(document.createTextNode(job));
 
             spanNode.insertAdjacentHTML(
                 'beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -849,6 +849,23 @@ require([
                 ]));
             aNode.appendChild(html.build());
 
+            spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+
+            tooltipNode = spanNode.appendChild(html.tooltip());
+            tooltipNode.title =
+                "Test reports for &#171;" + job + "&#187; - " + kernel;
+
+            aNode = tooltipNode.appendChild(document.createElement('a'));
+            var str = '/test/job/';
+            str += job;
+            str += '/branch/';
+            str += branch;
+            str += '/kernel/';
+            str += kernel;
+            str += '/';
+            aNode.setAttribute('href', str);
+            aNode.appendChild(html.stethoscope());
+
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);
 

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -764,6 +764,8 @@ require([
         var spanNode;
         var tURLs;
         var tooltipNode;
+        var branchNode;
+        var branchLink;
 
         results = response.result;
         if (results.length === 0) {
@@ -807,9 +809,17 @@ require([
             html.replaceContent(document.getElementById('tree'), docFrag);
 
             // Branch.
+            branchNode = html.tooltip();
+            branchNode.title =
+                "Branch reports for &#171;" + job + "&#187; - " + branch;
+            branchLink = document.createElement('a');
+            branchLink.href = "/job/" + job + "/branch/" + branch;
+            branchLink.appendChild(html.tree());
+            branchNode.appendChild(document.createTextNode(branch));
+            branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+            branchNode.appendChild(branchLink);
             html.replaceContent(
-                document.getElementById('git-branch'),
-                document.createTextNode(branch));
+                document.getElementById('git-branch'), branchNode);
 
             // Git describe.
             docFrag = document.createDocumentFragment();

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -764,8 +764,6 @@ require([
         var spanNode;
         var tURLs;
         var tooltipNode;
-        var branchNode;
-        var branchLink;
 
         results = response.result;
         if (results.length === 0) {
@@ -809,17 +807,17 @@ require([
             html.replaceContent(document.getElementById('tree'), docFrag);
 
             // Branch.
-            branchNode = html.tooltip();
-            branchNode.title =
-                "Branch reports for &#171;" + job + "&#187; - " + branch;
-            branchLink = document.createElement('a');
-            branchLink.href = "/job/" + job + "/branch/" + branch;
-            branchLink.appendChild(html.tree());
-            branchNode.appendChild(document.createTextNode(branch));
-            branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-            branchNode.appendChild(branchLink);
+            tooltipNode = html.tooltip();
+            tooltipNode.title =
+                "All results for branch &#171;" + branch + "&#187;";
+            aNode = document.createElement('a');
+            aNode.href = "/job/" + job + "/branch/" + branch;
+            aNode.appendChild(html.tree());
+            tooltipNode.appendChild(document.createTextNode(branch));
+            tooltipNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+            tooltipNode.appendChild(aNode);
             html.replaceContent(
-                document.getElementById('git-branch'), branchNode);
+                document.getElementById('git-branch'), tooltipNode);
 
             // Git describe.
             docFrag = document.createDocumentFragment();

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.5.js
@@ -856,15 +856,10 @@ require([
                 "Test reports for &#171;" + job + "&#187; - " + kernel;
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
-            var str = '/test/job/';
-            str += job;
-            str += '/branch/';
-            str += branch;
-            str += '/kernel/';
-            str += kernel;
-            str += '/';
-            aNode.setAttribute('href', str);
-            aNode.appendChild(html.stethoscope());
+            aNode.href =
+                "/test/job/" + job + "/branch/" + branch +
+                "/kernel/" + kernel + "/";
+            aNode.appendChild(html.test());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-job-kernel-defconfig-logs.2017.4.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel-defconfig-logs.2017.4.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -361,7 +361,7 @@ require([
             str += kernel;
             str += '/';
             aNode.setAttribute('href', str);
-            aNode.appendChild(html.stethoscope());
+            aNode.appendChild(html.test());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-job-kernel-defconfig-logs.2017.4.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel-defconfig-logs.2017.4.js
@@ -361,7 +361,7 @@ require([
             str += kernel;
             str += '/';
             aNode.setAttribute('href', str);
-            aNode.appendChild(html.boot());
+            aNode.appendChild(html.stethoscope());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-job-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel.2020.5.js
@@ -255,15 +255,10 @@ require([
                 "Test reports for &#171;" + job + "&#187; - " + kernel;
 
             aNode = tooltipNode.appendChild(document.createElement('a'));
-            var str = '/test/job/';
-            str += job;
-            str += '/branch/';
-            str += branch;
-            str += '/kernel/';
-            str += kernel;
-            str += '/';
-            aNode.setAttribute('href', str);
-            aNode.appendChild(html.stethoscope());
+            aNode.href =
+                "/test/job/" + job + "/branch/" + branch +
+                "/kernel/" + kernel + "/";
+            aNode.appendChild(html.test());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-job-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel.2020.5.js
@@ -238,7 +238,7 @@ require([
             aNode.setAttribute(
                 'href',
                 u.createPathHref([
-                    '/test/job/',
+                    '/build/',
                     job,
                     'branch',
                     branch,
@@ -246,7 +246,7 @@ require([
                     kernel,
                     '/'
                 ]));
-            aNode.appendChild(html.boot());
+            aNode.appendChild(html.build());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-builds-job-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-builds-job-kernel.2020.5.js
@@ -232,7 +232,7 @@ require([
             tooltipNode = spanNode.appendChild(html.tooltip());
             tooltipNode.setAttribute(
                 'title',
-                'Test reports for ' + job + '&nbsp;&ndash;&nbsp;' + kernel
+                'Build reports for ' + job + '&nbsp;&ndash;&nbsp;' + kernel
             );
             aNode = tooltipNode.appendChild(document.createElement('a'));
             aNode.setAttribute(
@@ -247,6 +247,23 @@ require([
                     '/'
                 ]));
             aNode.appendChild(html.build());
+
+            spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+
+            tooltipNode = spanNode.appendChild(html.tooltip());
+            tooltipNode.title =
+                "Test reports for &#171;" + job + "&#187; - " + kernel;
+
+            aNode = tooltipNode.appendChild(document.createElement('a'));
+            var str = '/test/job/';
+            str += job;
+            str += '/branch/';
+            str += branch;
+            str += '/kernel/';
+            str += kernel;
+            str += '/';
+            aNode.setAttribute('href', str);
+            aNode.appendChild(html.stethoscope());
 
             html.replaceContent(
                 document.getElementById('git-describe'), docFrag);

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.5.js
@@ -78,8 +78,7 @@ require([
 
         // Branch.
         branchNode = html.tooltip();
-        branchNode.title =
-            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchNode.title = "All results for branch &#171;" + branch + "&#187;";
         branchLink = document.createElement('a');
         branchLink.href = "/job/" + job + "/branch/" + branch;
         branchLink.appendChild(html.tree());

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.5.js
@@ -93,7 +93,8 @@ require([
         describeNode.title =
             "Build reports for &#171;" + job + "&#187; - " + kernel;
         buildsLink = document.createElement('a');
-        buildsLink.href = "/build/" + job + "/kernel/" + kernel;
+        buildsLink.href =
+            "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.5.js
@@ -58,6 +58,8 @@ require([
         var gitNode;
         var createdOn;
         var dateNode;
+        var branchNode;
+        var branchLink;
 
         soc = results.mach;
         job = results.job;
@@ -73,6 +75,20 @@ require([
         treeNode.appendChild(document.createTextNode(job));
         treeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         treeNode.appendChild(jobLink);
+
+        // Branch.
+        branchNode = html.tooltip();
+        branchNode.title =
+            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchLink = document.createElement('a');
+        branchLink.href = "/job/" + job + "/branch/" + branch;
+        branchLink.appendChild(html.tree());
+        branchNode.appendChild(document.createTextNode(branch));
+        branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        branchNode.appendChild(branchLink);
+
+        html.replaceContent(
+            document.getElementById('git-branch'), branchNode);
 
         describeNode = html.tooltip();
         describeNode.title =
@@ -100,9 +116,6 @@ require([
             document.createTextNode(soc));
         html.replaceContent(
             document.getElementById('tree'), treeNode);
-        html.replaceContent(
-            document.getElementById('git-branch'),
-            document.createTextNode(branch));
         html.replaceContent(
             document.getElementById('git-describe'), describeNode);
         html.replaceContent(

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
@@ -61,9 +61,7 @@ define([
             gitCommit,
             gitURL,
             gitURLs,
-            tooltipNode,
-            branchNode,
-            branchLink;
+            tooltipNode;
 
         gitBranch = results.git_branch;
         gitCommit = results.git_commit;
@@ -109,18 +107,18 @@ define([
         html.replaceContent(document.getElementById('tree'), domNode);
 
         // Branch.
-        branchNode = html.tooltip();
-        branchNode.title =
-            "Branch reports for &#171;" + gJob + "&#187; - " + gitBranch;
-        branchLink = document.createElement('a');
-        branchLink.href = "/job/" + gJob + "/branch/" + gitBranch;
-        branchLink.appendChild(html.tree());
-        branchNode.appendChild(document.createTextNode(gitBranch));
-        branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-        branchNode.appendChild(branchLink);
+        tooltipNode = html.tooltip();
+        tooltipNode.title =
+            "All results for branch &#171;" + gitBranch + "&#187;";
+        aNode = document.createElement('a');
+        aNode.href = "/job/" + gJob + "/branch/" + gitBranch;
+        aNode.appendChild(html.tree());
+        tooltipNode.appendChild(document.createTextNode(gitBranch));
+        tooltipNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        tooltipNode.appendChild(aNode);
 
         html.replaceContent(
-            document.getElementById('git-branch'), branchNode);
+            document.getElementById('git-branch'), tooltipNode);
 
         // Git describe.
         domNode = document.createElement('div');

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
@@ -150,7 +150,7 @@ define([
         str += gKernel;
         str += '/';
         aNode.setAttribute('href', str);
-        aNode.appendChild(html.stethoscope());
+        aNode.appendChild(html.test());
 
         tooltipNode.appendChild(aNode);
         domNode.appendChild(tooltipNode);

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
@@ -135,6 +135,25 @@ define([
         tooltipNode.appendChild(aNode);
 
         domNode.appendChild(tooltipNode);
+        domNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+
+        tooltipNode = domNode.appendChild(html.tooltip());
+        tooltipNode.title =
+            "Test reports for &#171;" + gJob + "&#187; - " + gKernel;
+
+        aNode = tooltipNode.appendChild(document.createElement('a'));
+        var str = '/test/job/';
+        str += gJob;
+        str += '/branch/';
+        str += gitBranch;
+        str += '/kernel/';
+        str += gKernel;
+        str += '/';
+        aNode.setAttribute('href', str);
+        aNode.appendChild(html.stethoscope());
+
+        tooltipNode.appendChild(aNode);
+        domNode.appendChild(tooltipNode);
 
         html.replaceContent(
             document.getElementById('git-describe'), domNode);

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
@@ -61,7 +61,9 @@ define([
             gitCommit,
             gitURL,
             gitURLs,
-            tooltipNode;
+            tooltipNode,
+            branchNode,
+            branchLink;
 
         gitBranch = results.git_branch;
         gitCommit = results.git_commit;
@@ -106,10 +108,19 @@ define([
 
         html.replaceContent(document.getElementById('tree'), domNode);
 
-        // Git branch.
+        // Branch.
+        branchNode = html.tooltip();
+        branchNode.title =
+            "Branch reports for &#171;" + gJob + "&#187; - " + gitBranch;
+        branchLink = document.createElement('a');
+        branchLink.href = "/job/" + gJob + "/branch/" + gitBranch;
+        branchLink.appendChild(html.tree());
+        branchNode.appendChild(document.createTextNode(gitBranch));
+        branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        branchNode.appendChild(branchLink);
+
         html.replaceContent(
-            document.getElementById('git-branch'),
-            document.createTextNode(gitBranch));
+            document.getElementById('git-branch'), branchNode);
 
         // Git describe.
         domNode = document.createElement('div');
@@ -433,6 +444,7 @@ define([
                 'job',
                 'mach',
                 'git_commit',
+                'git_branch',
                 'git_url',
                 'kernel',
             ],

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.5.js
@@ -126,12 +126,11 @@ define([
         domNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
         tooltipNode = html.tooltip();
-        tooltipNode.setAttribute(
-            'title',
-            'Build reports for &#171;' + gJob + '&#187; - ' + gKernel);
+        tooltipNode.title =
+            "Build reports for &#171;" + gJob + "&#187; - " + gKernel;
         aNode = document.createElement('a');
-        aNode.setAttribute(
-            'href', '/build/' + gJob + '/kernel/' + gKernel);
+        aNode.href =
+            "/build/" + gJob + "/branch/" + gitBranch + "/kernel/" + gKernel;
         aNode.appendChild(html.build());
         tooltipNode.appendChild(aNode);
 

--- a/app/dashboard/static/js/app/view-tests-case-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-case-id.2020.5.js
@@ -75,7 +75,8 @@ require([
         describeNode.title =
             "Build reports for &#171;" + job + "&#187; - " + kernel;
         buildsLink = document.createElement('a');
-        buildsLink.href = "/build/" + job + "/kernel/" + kernel;
+        buildsLink.href =
+            "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-tests-case-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-case-id.2020.5.js
@@ -47,6 +47,7 @@ require([
     function updateCaseDetails(results) {
         var job;
         var kernel;
+        var branch;
         var treeNode;
         var jobLink;
         var describeNode;
@@ -54,9 +55,12 @@ require([
         var createdOn;
         var dateNode;
         var status;
+        var branchNode;
+        var branchLink;
 
         job = results.job;
         kernel = results.kernel;
+        branch = results.git_branch;
 
         treeNode = html.tooltip();
         treeNode.title = "Details for tree &#171;" + job + "&#187;";
@@ -76,6 +80,17 @@ require([
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         describeNode.appendChild(buildsLink);
+
+        // Branch.
+        branchNode = html.tooltip();
+        branchNode.title =
+            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchLink = document.createElement('a');
+        branchLink.href = "/job/" + job + "/branch/" + branch;
+        branchLink.appendChild(html.tree());
+        branchNode.appendChild(document.createTextNode(branch));
+        branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        branchNode.appendChild(branchLink);
 
         createdOn = new Date(results.created_on.$date);
         dateNode = document.createElement('time');
@@ -109,8 +124,7 @@ require([
         html.replaceContent(
             document.getElementById('tree'), treeNode);
         html.replaceContent(
-            document.getElementById('git-branch'),
-            document.createTextNode(results.git_branch));
+            document.getElementById('git-branch'), branchNode);
         html.replaceContent(
             document.getElementById('git-describe'), describeNode);
         html.replaceContent(  /* ToDo: link to commit when possible */

--- a/app/dashboard/static/js/app/view-tests-case-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-case-id.2020.5.js
@@ -48,22 +48,29 @@ require([
         var job;
         var kernel;
         var branch;
+        var plan;
         var treeNode;
         var jobLink;
         var describeNode;
+        var buildsNode;
         var buildsLink;
+        var testsNode;
+        var testsLink;
         var createdOn;
         var dateNode;
         var status;
         var branchNode;
         var branchLink;
+        var planNode;
+        var planLink;
 
         job = results.job;
         kernel = results.kernel;
         branch = results.git_branch;
+        plan = results.plan;
 
         treeNode = html.tooltip();
-        treeNode.title = "Details for tree &#171;" + job + "&#187;";
+        treeNode.title = "All results for tree &#171;" + job + "&#187;";
         jobLink = document.createElement('a');
         jobLink.href = "/job/" + job + "/";
         jobLink.appendChild(html.tree());
@@ -71,16 +78,36 @@ require([
         treeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         treeNode.appendChild(jobLink);
 
-        describeNode = html.tooltip();
-        describeNode.title =
-            "Build reports for &#171;" + job + "&#187; - " + kernel;
-        buildsLink = document.createElement('a');
+        describeNode = document.createElement('span');
+        buildsNode = html.tooltip();
+        buildsNode.title = "Build reports for &#171;" + kernel + "&#187;";
+        buildsLink = buildsNode.appendChild(document.createElement('a'));
         buildsLink.href =
             "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
+        testsNode = html.tooltip();
+        testsNode.title = "Test results for &#171;" + kernel + "&#187;";
+        testsLink = document.createElement('a');
+        testsLink.href =
+            "/test/job/" + job + "/branch/" + branch + "/kernel/" + kernel;
+        testsLink.appendChild(html.test());
+        testsNode.appendChild(testsLink);
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-        describeNode.appendChild(buildsLink);
+        describeNode.appendChild(buildsNode);
+        describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        describeNode.appendChild(testsNode);
+
+        planNode = html.tooltip();
+        planNode.title = "All results for plan &#171;" + plan + "&#187;";
+        planLink = document.createElement('a');
+        planLink.href =
+            "/test/job/" + job + "/branch/" + branch +
+            "/kernel/" + kernel + "/plan/" + plan + "/";
+        planLink.appendChild(html.test());
+        planNode.appendChild(document.createTextNode(plan));
+        planNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        planNode.appendChild(planLink)
 
         // Branch.
         branchNode = html.tooltip();
@@ -130,6 +157,8 @@ require([
         html.replaceContent(  /* ToDo: link to commit when possible */
             document.getElementById('git-commit'),
             document.createTextNode(results.git_commit));
+        html.replaceContent(
+            document.getElementById('plan'), planNode);
         html.replaceContent(
             document.getElementById('arch'),
             document.createTextNode(results.arch));

--- a/app/dashboard/static/js/app/view-tests-case-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-case-id.2020.5.js
@@ -83,8 +83,7 @@ require([
 
         // Branch.
         branchNode = html.tooltip();
-        branchNode.title =
-            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchNode.title = "All results for branch &#171;" + branch + "&#187;";
         branchLink = document.createElement('a');
         branchLink.href = "/job/" + job + "/branch/" + branch;
         branchLink.appendChild(html.tree());

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.5.js
@@ -93,7 +93,8 @@ require([
         describeNode.title =
             "Build reports for &#171;" + job + "&#187; - " + kernel;
         buildsLink = document.createElement('a');
-        buildsLink.href = "/build/" + job + "/kernel/" + kernel;
+        buildsLink.href =
+            "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.5.js
@@ -58,7 +58,10 @@ require([
         var treeNode;
         var jobLink;
         var describeNode;
+        var buildsNode
         var buildsLink;
+        var testsNode;
+        var testsLink;
         var gitNode;
         var createdOn;
         var dateNode;
@@ -71,7 +74,7 @@ require([
         commit = results.git_commit;
 
         treeNode = html.tooltip();
-        treeNode.title = "Details for tree &#171;" + job + "&#187;";
+        treeNode.title = "All results for tree &#171;" + job + "&#187;";
         jobLink = document.createElement('a');
         jobLink.href = "/job/" + job + "/";
         jobLink.appendChild(html.tree());
@@ -79,7 +82,6 @@ require([
         treeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         treeNode.appendChild(jobLink);
 
-        // Branch.
         branchNode = html.tooltip();
         branchNode.title = "All results for branch &#171;" + branch + "&#187;";
         branchLink = document.createElement('a');
@@ -89,16 +91,25 @@ require([
         branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         branchNode.appendChild(branchLink);
 
-        describeNode = html.tooltip();
-        describeNode.title =
-            "Build reports for &#171;" + job + "&#187; - " + kernel;
-        buildsLink = document.createElement('a');
+        describeNode = document.createElement('span');
+        buildsNode = html.tooltip();
+        buildsNode.title = "Build results for &#171;" + kernel + "&#187;";
+        buildsLink = buildsNode.appendChild(document.createElement('a'));
         buildsLink.href =
             "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
+        testsNode = html.tooltip();
+        testsNode.title = "Test results for &#171;" + kernel + "&#187;";
+        testsLink = testsNode.appendChild(document.createElement('a'));
+        testsLink.href =
+            "/test/job/" + job + "/branch/" + branch +
+            "/kernel/" + kernel + "/";
+        testsLink.appendChild(html.test());
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-        describeNode.appendChild(buildsLink);
+        describeNode.appendChild(buildsNode);
+        describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        describeNode.appendChild(testsNode);
 
         gitNode = document.createElement('a');
         gitNode.appendChild(document.createTextNode(results.git_url));

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.5.js
@@ -81,8 +81,7 @@ require([
 
         // Branch.
         branchNode = html.tooltip();
-        branchNode.title =
-            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchNode.title = "All results for branch &#171;" + branch + "&#187;";
         branchLink = document.createElement('a');
         branchLink.href = "/job/" + job + "/branch/" + branch;
         branchLink.appendChild(html.tree());

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.5.js
@@ -62,6 +62,8 @@ require([
         var gitNode;
         var createdOn;
         var dateNode;
+        var branchNode;
+        var branchLink;
 
         job = results.job;
         branch = results.git_branch;
@@ -76,6 +78,17 @@ require([
         treeNode.appendChild(document.createTextNode(job));
         treeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         treeNode.appendChild(jobLink);
+
+        // Branch.
+        branchNode = html.tooltip();
+        branchNode.title =
+            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchLink = document.createElement('a');
+        branchLink.href = "/job/" + job + "/branch/" + branch;
+        branchLink.appendChild(html.tree());
+        branchNode.appendChild(document.createTextNode(branch));
+        branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        branchNode.appendChild(branchLink);
 
         describeNode = html.tooltip();
         describeNode.title =
@@ -101,8 +114,7 @@ require([
         html.replaceContent(
             document.getElementById('tree'), treeNode);
         html.replaceContent(
-            document.getElementById('git-branch'),
-            document.createTextNode(branch));
+            document.getElementById('git-branch'), branchNode);
         html.replaceContent(
             document.getElementById('git-describe'), describeNode);
         html.replaceContent(

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
@@ -63,7 +63,7 @@ require([
         commit = results.git_commit;
 
         treeNode = html.tooltip();
-        treeNode.title = "Details for tree &#171;" + job + "&#187;"
+        treeNode.title = "All results for tree &#171;" + job + "&#187;"
         jobLink = document.createElement('a');
         jobLink.href = "/job/" + job + "/";
         jobLink.appendChild(html.tree());

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
@@ -86,7 +86,7 @@ require([
         describeNode.title =
             "Build reports for &#171;" + job + "&#187; - " + kernel;
         buildsLink = document.createElement('a');
-        buildsLink.href = "/build/" + job + "/kernel/" + kernel;
+        buildsLink.href = "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
@@ -83,10 +83,10 @@ require([
         branchNode.appendChild(branchLink);
 
         describeNode = html.tooltip();
-        describeNode.title =
-            "Build reports for &#171;" + job + "&#187; - " + kernel;
+        describeNode.title = "Build results for &#171;" + kernel + "&#187; - ";
         buildsLink = document.createElement('a');
-        buildsLink.href = "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
+        buildsLink.href =
+            "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
@@ -29,7 +29,8 @@ require([
     'tables/test',
     'charts/passpie',
     'URI',
-], function($, init, html, error, request, table, ttest, chart, URI) {
+    'utils/urls',
+], function($, init, html, error, request, table, ttest, chart, URI, urls) {
     'use strict';
     var gJob;
     var gBranch;
@@ -52,12 +53,14 @@ require([
         var treeNode;
         var jobLink;
         var describeNode;
-        var buildsLink;
         var branchNode;
         var branchLink;
         var gitNode;
         var createdOn;
         var dateNode;
+        var aNode;
+        var spanNode;
+        var tooltipNode;
 
         job = results.job;
         branch = results.git_branch;
@@ -82,15 +85,53 @@ require([
         branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         branchNode.appendChild(branchLink);
 
-        describeNode = html.tooltip();
-        describeNode.title =
-            "Build reports for &#171;" + job + "&#187; - " + kernel;
-        buildsLink = document.createElement('a');
-        buildsLink.href = "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
-        buildsLink.appendChild(html.build());
-        describeNode.appendChild(document.createTextNode(kernel));
-        describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-        describeNode.appendChild(buildsLink);
+                // Git describe.
+        describeNode = document.createDocumentFragment();
+        spanNode = describeNode.appendChild(document.createElement('span'));
+
+        spanNode.appendChild(document.createTextNode(kernel));
+
+        spanNode.insertAdjacentHTML(
+            'beforeend', '&nbsp;&mdash;&nbsp;');
+
+        tooltipNode = spanNode.appendChild(html.tooltip());
+        tooltipNode.setAttribute(
+            'title',
+            'Build reports for ' + job + '&nbsp;&ndash;&nbsp;' + kernel
+        );
+        aNode = tooltipNode.appendChild(document.createElement('a'));
+        aNode.setAttribute(
+            'href',
+            urls.createPathHref([
+                '/build/',
+                job,
+                'branch',
+                branch,
+                'kernel',
+                kernel,
+                '/'
+            ]));
+        aNode.appendChild(html.build());
+
+        spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+
+        tooltipNode = spanNode.appendChild(html.tooltip());
+        tooltipNode.title =
+            "Test reports for &#171;" + job + "&#187; - " + kernel;
+
+        aNode = tooltipNode.appendChild(document.createElement('a'));
+        aNode.setAttribute(
+            'href',
+            urls.createPathHref([
+                '/test/job/',
+                job,
+                '/branch/',
+                branch,
+                '/kernel/',
+                kernel,
+                '/'
+            ]));
+        aNode.appendChild(html.stethoscope());
 
         gitNode = document.createElement('a');
         gitNode.appendChild(document.createTextNode(results.git_url));

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
@@ -29,8 +29,7 @@ require([
     'tables/test',
     'charts/passpie',
     'URI',
-    'utils/urls',
-], function($, init, html, error, request, table, ttest, chart, URI, urls) {
+], function($, init, html, error, request, table, ttest, chart, URI) {
     'use strict';
     var gJob;
     var gBranch;
@@ -53,14 +52,12 @@ require([
         var treeNode;
         var jobLink;
         var describeNode;
+        var buildsLink;
         var branchNode;
         var branchLink;
         var gitNode;
         var createdOn;
         var dateNode;
-        var aNode;
-        var spanNode;
-        var tooltipNode;
 
         job = results.job;
         branch = results.git_branch;
@@ -85,53 +82,15 @@ require([
         branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         branchNode.appendChild(branchLink);
 
-                // Git describe.
-        describeNode = document.createDocumentFragment();
-        spanNode = describeNode.appendChild(document.createElement('span'));
-
-        spanNode.appendChild(document.createTextNode(kernel));
-
-        spanNode.insertAdjacentHTML(
-            'beforeend', '&nbsp;&mdash;&nbsp;');
-
-        tooltipNode = spanNode.appendChild(html.tooltip());
-        tooltipNode.setAttribute(
-            'title',
-            'Build reports for ' + job + '&nbsp;&ndash;&nbsp;' + kernel
-        );
-        aNode = tooltipNode.appendChild(document.createElement('a'));
-        aNode.setAttribute(
-            'href',
-            urls.createPathHref([
-                '/build/',
-                job,
-                'branch',
-                branch,
-                'kernel',
-                kernel,
-                '/'
-            ]));
-        aNode.appendChild(html.build());
-
-        spanNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-
-        tooltipNode = spanNode.appendChild(html.tooltip());
-        tooltipNode.title =
-            "Test reports for &#171;" + job + "&#187; - " + kernel;
-
-        aNode = tooltipNode.appendChild(document.createElement('a'));
-        aNode.setAttribute(
-            'href',
-            urls.createPathHref([
-                '/test/job/',
-                job,
-                '/branch/',
-                branch,
-                '/kernel/',
-                kernel,
-                '/'
-            ]));
-        aNode.appendChild(html.test());
+        describeNode = html.tooltip();
+        describeNode.title =
+            "Build reports for &#171;" + job + "&#187; - " + kernel;
+        buildsLink = document.createElement('a');
+        buildsLink.href = "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
+        buildsLink.appendChild(html.build());
+        describeNode.appendChild(document.createTextNode(kernel));
+        describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        describeNode.appendChild(buildsLink);
 
         gitNode = document.createElement('a');
         gitNode.appendChild(document.createTextNode(results.git_url));

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
@@ -74,8 +74,7 @@ require([
         treeNode.appendChild(jobLink);
 
         branchNode = html.tooltip();
-        branchNode.title =
-            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchNode.title = "All results for branch &#171;" + branch + "&#187;";
         branchLink = document.createElement('a');
         branchLink.href = "/job/" + job + "/branch/" + branch;
         branchLink.appendChild(html.tree());

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
@@ -131,7 +131,7 @@ require([
                 kernel,
                 '/'
             ]));
-        aNode.appendChild(html.stethoscope());
+        aNode.appendChild(html.test());
 
         gitNode = document.createElement('a');
         gitNode.appendChild(document.createTextNode(results.git_url));

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.5.js
@@ -53,6 +53,8 @@ require([
         var jobLink;
         var describeNode;
         var buildsLink;
+        var branchNode;
+        var branchLink;
         var gitNode;
         var createdOn;
         var dateNode;
@@ -70,6 +72,16 @@ require([
         treeNode.appendChild(document.createTextNode(job));
         treeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         treeNode.appendChild(jobLink);
+
+        branchNode = html.tooltip();
+        branchNode.title =
+            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchLink = document.createElement('a');
+        branchLink.href = "/job/" + job + "/branch/" + branch;
+        branchLink.appendChild(html.tree());
+        branchNode.appendChild(document.createTextNode(branch));
+        branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        branchNode.appendChild(branchLink);
 
         describeNode = html.tooltip();
         describeNode.title =
@@ -95,8 +107,7 @@ require([
         html.replaceContent(
             document.getElementById('tree'), treeNode);
         html.replaceContent(
-            document.getElementById('git-branch'),
-            document.createTextNode(branch));
+            document.getElementById('git-branch'), branchNode);
         html.replaceContent(
             document.getElementById('git-describe'), describeNode);
         html.replaceContent(

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -109,7 +109,7 @@ require([
         testsLink = testsNode.appendChild(document.createElement('a'));
         testsLink.href =
             "/test/job/" + job + "/branch/" + branch + "/kernel/" + kernel;
-        testsLink.appendChild(html.stethoscope());
+        testsLink.appendChild(html.test());
         testsNode.appendChild(testsLink);
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -69,7 +69,7 @@ require([
         kernel = results.kernel;
 
         treeNode = html.tooltip();
-        treeNode.title = "Details for tree &#171;" + job + "&#187;";
+        treeNode.title = "All results for tree &#171;" + job + "&#187;";
         jobLink = document.createElement('a');
         jobLink.href = "/job/" + job + "/";
         jobLink.appendChild(html.tree());

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -63,6 +63,8 @@ require([
         var dateNode;
         var translatedURI;
         var logNode;
+        var branchNode;
+        var branchLink;
 
         job = results.job;
         branch = results.git_branch;
@@ -76,6 +78,17 @@ require([
         treeNode.appendChild(document.createTextNode(job));
         treeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         treeNode.appendChild(jobLink);
+
+        // Branch.
+        branchNode = html.tooltip();
+        branchNode.title =
+            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchLink = document.createElement('a');
+        branchLink.href = "/job/" + job + "/branch/" + branch;
+        branchLink.appendChild(html.tree());
+        branchNode.appendChild(document.createTextNode(branch));
+        branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        branchNode.appendChild(branchLink);
 
         describeNode = document.createElement('span')
         buildsNode = html.tooltip();
@@ -127,8 +140,7 @@ require([
         html.replaceContent(
             document.getElementById('tree'), treeNode);
         html.replaceContent(
-            document.getElementById('git-branch'),
-            document.createTextNode(results.git_branch));
+            document.getElementById('git-branch'), branchNode);
         html.replaceContent(
             document.getElementById('git-describe'), describeNode);
         html.replaceContent(

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -65,10 +65,14 @@ require([
         var logNode;
         var branchNode;
         var branchLink;
+        var defconfigFull;
+        var defconfigLink;
+        var defconfigNode;
 
         job = results.job;
         branch = results.git_branch;
         kernel = results.kernel;
+        defconfigFull = results.defconfig_full;
 
         treeNode = html.tooltip();
         treeNode.title = "All results for tree &#171;" + job + "&#187;";
@@ -108,6 +112,17 @@ require([
         describeNode.appendChild(buildsNode);
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         describeNode.appendChild(testsNode);
+
+        // Defconfig.
+        defconfigNode = html.tooltip();
+        defconfigNode.title =
+            "defconfig reports for &#171;" + job + "&#187; - " + defconfigFull;
+        defconfigLink = document.createElement('a');
+        defconfigLink.href = "/build/id/" + results._id.$oid;
+        defconfigLink.appendChild(html.build());
+        defconfigNode.appendChild(document.createTextNode(defconfigFull));
+        defconfigNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        defconfigNode.appendChild(defconfigLink);
 
         gitNode = document.createElement('a');
         gitNode.appendChild(document.createTextNode(results.git_url));
@@ -149,8 +164,7 @@ require([
             document.getElementById('arch'),
             document.createTextNode(results.arch));
         html.replaceContent(
-            document.getElementById('defconfig'),
-            document.createTextNode(results.defconfig_full));
+            document.getElementById('defconfig'), defconfigNode);
         html.replaceContent(
             document.getElementById('compiler'),
             document.createTextNode(results.compiler_version_full));

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -89,25 +89,22 @@ require([
         branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         branchNode.appendChild(branchLink);
 
-        describeNode = document.createElement('span')
+        describeNode = document.createElement('span');
         buildsNode = html.tooltip();
-        buildsNode.title =
-            "Build reports for &#171;" + job + "&#187; - " + kernel;
-        buildsLink = document.createElement('a');
+        buildsNode.title = "Build results for &#171;" + kernel + "&#187;";
+        buildsLink = buildsNode.appendChild(document.createElement('a'));
         buildsLink.href =
             "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
-        buildsNode.appendChild(document.createTextNode(kernel));
-        buildsNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
-        buildsNode.appendChild(buildsLink);
         testsNode = html.tooltip();
-        testsNode.title =
-            "Test reports for &#171;" + job + "&#187; - " + kernel;
-        testsLink = document.createElement('a');
+        testsNode.title = "Test results for &#171;" + kernel + "&#187;";
+        testsLink = testsNode.appendChild(document.createElement('a'));
         testsLink.href =
             "/test/job/" + job + "/branch/" + branch + "/kernel/" + kernel;
         testsLink.appendChild(html.boot());
         testsNode.appendChild(testsLink);
+        describeNode.appendChild(document.createTextNode(kernel));
+        describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         describeNode.appendChild(buildsNode);
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
         describeNode.appendChild(testsNode);

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -109,7 +109,7 @@ require([
         testsLink = testsNode.appendChild(document.createElement('a'));
         testsLink.href =
             "/test/job/" + job + "/branch/" + branch + "/kernel/" + kernel;
-        testsLink.appendChild(html.boot());
+        testsLink.appendChild(html.stethoscope());
         testsNode.appendChild(testsLink);
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -66,13 +66,17 @@ require([
         var branchNode;
         var branchLink;
         var defconfigFull;
-        var defconfigLink;
         var defconfigNode;
+        var defconfigPath;
+        var defconfigLink;
+        var buildLink;
 
         job = results.job;
         branch = results.git_branch;
         kernel = results.kernel;
         defconfigFull = results.defconfig_full;
+
+        translatedURI = urls.createFileServerURL(gFileServer, results);
 
         treeNode = html.tooltip();
         treeNode.title = "All results for tree &#171;" + job + "&#187;";
@@ -115,14 +119,22 @@ require([
 
         // Defconfig.
         defconfigNode = html.tooltip();
-        defconfigNode.title =
-            "defconfig reports for &#171;" + job + "&#187; - " + defconfigFull;
         defconfigLink = document.createElement('a');
-        defconfigLink.href = "/build/id/" + results._id.$oid;
-        defconfigLink.appendChild(html.build());
-        defconfigNode.appendChild(document.createTextNode(defconfigFull));
-        defconfigNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        defconfigLink.appendChild(
+            document.createTextNode(results.defconfig_full));
+        defconfigPath = translatedURI[1] + "/kernel.config";
+        defconfigLink.href =
+            translatedURI[0].path(defconfigPath).normalizePath().href();
+        defconfigLink.title = "Defconfig URL";
+        defconfigLink.insertAdjacentHTML('beforeend', '&nbsp;');
+        defconfigLink.appendChild(html.external());
         defconfigNode.appendChild(defconfigLink);
+        buildLink = document.createElement('a');
+        buildLink.href = "/build/id/" + results._id.$oid;
+        buildLink.appendChild(html.build());
+        buildLink.title = "Build details";
+        defconfigNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        defconfigNode.appendChild(buildLink);
 
         gitNode = document.createElement('a');
         gitNode.appendChild(document.createTextNode(results.git_url));
@@ -135,7 +147,6 @@ require([
         dateNode.appendChild(
             document.createTextNode(createdOn.toCustomISODate()));
 
-        translatedURI = urls.createFileServerURL(gFileServer, results);
         logNode = tcommon.logsNode(
             results.boot_log, results.boot_log_html, results.lab_name,
             translatedURI[0], translatedURI[1]);

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -81,8 +81,7 @@ require([
 
         // Branch.
         branchNode = html.tooltip();
-        branchNode.title =
-            "Branch reports for &#171;" + job + "&#187; - " + branch;
+        branchNode.title = "All results for branch &#171;" + branch + "&#187;";
         branchLink = document.createElement('a');
         branchLink.href = "/job/" + job + "/branch/" + branch;
         branchLink.appendChild(html.tree());

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -51,6 +51,7 @@ require([
         var job;
         var branch;
         var kernel;
+        var plan;
         var treeNode;
         var jobLink;
         var describeNode;
@@ -70,11 +71,14 @@ require([
         var defconfigPath;
         var defconfigLink;
         var buildLink;
+        var planNode;
+        var planLink;
 
         job = results.job;
         branch = results.git_branch;
         kernel = results.kernel;
         defconfigFull = results.defconfig_full;
+        plan = results.name;
 
         translatedURI = urls.createFileServerURL(gFileServer, results);
 
@@ -147,6 +151,17 @@ require([
         dateNode.appendChild(
             document.createTextNode(createdOn.toCustomISODate()));
 
+        planNode = html.tooltip();
+        planNode.title = "All results for plan &#171;" + plan + "&#187;";
+        planLink = document.createElement('a');
+        planLink.href =
+            "/test/job/" + job + "/branch/" + branch +
+            "/kernel/" + kernel + "/plan/" + plan + "/";
+        planLink.appendChild(html.test());
+        planNode.appendChild(document.createTextNode(plan));
+        planNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        planNode.appendChild(planLink)
+
         logNode = tcommon.logsNode(
             results.boot_log, results.boot_log_html, results.lab_name,
             translatedURI[0], translatedURI[1]);
@@ -171,6 +186,8 @@ require([
         html.replaceContent(  /* ToDo: link to commit when possible */
             document.getElementById('git-commit'),
             document.createTextNode(results.git_commit));
+        html.replaceContent(
+            document.getElementById('plan'), planNode);
         html.replaceContent(
             document.getElementById('arch'),
             document.createTextNode(results.arch));

--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.5.js
@@ -94,7 +94,8 @@ require([
         buildsNode.title =
             "Build reports for &#171;" + job + "&#187; - " + kernel;
         buildsLink = document.createElement('a');
-        buildsLink.href = "/build/" + job + "/kernel/" + kernel;
+        buildsLink.href =
+            "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
         buildsLink.appendChild(html.build());
         buildsNode.appendChild(document.createTextNode(kernel));
         buildsNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/templates/tests-case-id.html
+++ b/app/dashboard/templates/tests-case-id.html
@@ -68,6 +68,12 @@
           <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
         </small>
       </dd>
+      <dt>Plan</dt>
+      <dd id="plan" class="loading-content">
+        <small>
+          <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+        </small>
+      </dd>
       <dt>Git URL</dt>
       <dd id="git-url" class="loading-content">
         <small>

--- a/app/dashboard/templates/tests-plan-id.html
+++ b/app/dashboard/templates/tests-plan-id.html
@@ -32,6 +32,12 @@
                 <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
             </small>
         </dd>
+        <dt>Plan</dt>
+        <dd id="plan" class="loading-content">
+          <small>
+            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+          </small>
+        </dd>
         <dt>Git URL</dt>
         <dd id="git-url" class="loading-content">
           <small>


### PR DESCRIPTION
Replaces #111.

Note: The link to test plan results in single test case view is being dropped as there is no test plan group ID available in the test case document model, only the test group ID.  The top-level test plan group ID can be found recursively, but that would mean many queries.  So a new field needs to be added to the test case document "plan_id" for this kind of link to be enabled on the frontend.