### PR TITLE
T21353 Add regression links to tests-job-branch-kernel-plan

### DIFF
--- a/app/dashboard/static/js/app/components/test/view.js
+++ b/app/dashboard/static/js/app/components/test/view.js
@@ -433,7 +433,7 @@ define([
         aNode = document.createElement('a');
         aNode.setAttribute(
             'href', urls.createPathHref(['/test/plan/id/', docId, '/']));
-        aNode.appendChild(document.createTextNode('More info'));
+        aNode.appendChild(document.createTextNode('Full results'));
         aNode.insertAdjacentHTML('beforeend', '&nbsp;');
         aNode.appendChild(html.search());
         tooltipNode.appendChild(aNode);

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.6.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.6.js
@@ -58,7 +58,7 @@ require([
         var treeNode;
         var jobLink;
         var describeNode;
-        var buildsNode
+        var buildsNode;
         var buildsLink;
         var testsNode;
         var testsLink;
@@ -274,6 +274,8 @@ require([
                 var nodeId = data.operation_id + '-regression';
                 var regrNode;
                 var regrInfo;
+                var regrCase;
+                var regrLink;
                 var dlNode;
                 var dtNode;
                 var testCase;
@@ -302,8 +304,14 @@ require([
                 regrNode.appendChild(document.createElement('hr'));
                 dlNode = document.createElement('dl');
                 dlNode.className = 'dl-horizontal';
+                regrLink = document.createElement('a');
+                regrCase = regr.regressions[regr.regressions.length - 1];
+                regrLink.href = '/test/case/id/' + regrCase.test_case_id.$oid;
+                regrLink.appendChild(document.createTextNode(testCase));
                 dtNode = document.createElement('dt');
-                dtNode.appendChild(document.createTextNode(testCase));
+                dtNode.appendChild(html.fail());
+                dtNode.insertAdjacentHTML('beforeend', '&nbsp;&nbsp;');
+                dtNode.appendChild(regrLink);
                 dlNode.appendChild(dtNode);
                 dlNode.appendChild(regrInfo);
                 regrNode.appendChild(dlNode);


### PR DESCRIPTION
Add direct links to the test cases that have some regressions in the
tests-job-branch-kernel-plan view.  This avoids having to open the
full results, look for regressions and then open the relevant test
case.

Also change the "More info" link to "Full results" as it's clearer
that it will be showing all the results, rather than more regression
information.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>