### PR TITLE
T23358 unknown status fixup

### DIFF
--- a/app/dashboard/static/css/kci-base-2020.2.css
+++ b/app/dashboard/static/css/kci-base-2020.2.css
@@ -117,7 +117,7 @@ td.kernel-column-nf,
     cursor: default;
     user-select: none;
 }
-#success-cell, #fail-cell, #unknown-cell {
+#success-cell, #fail-cell, #warning-cell, #unknown-cell {
     cursor: pointer;
 }
 .pie-chart {

--- a/app/dashboard/static/js/app/buttons/build.js
+++ b/app/dashboard/static/js/app/buttons/build.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -77,21 +77,26 @@ define([
     function checkButtonStatus() {
         var failBtn;
         var successBtn;
+        var warningBtn;
         var unknownBtn;
 
         successBtn = document.getElementById('success-btn');
         failBtn = document.getElementById('fail-btn');
+        warningBtn = document.getElementById('warning-btn');
         unknownBtn = document.getElementById('unknown-btn');
 
         if (html.classed(successBtn, 'active')) {
             common.showAllByClass('df-success');
         } else if (html.classed(failBtn, 'active')) {
             common.showAllByClass('df-failed');
+        } else if (html.classed(warningBtn, 'active')) {
+            common.showAllByClass('df-warning');
         } else if (html.classed(unknownBtn, 'active')) {
             common.showAllByClass('df-unknown');
         } else {
-            common.showAllByClass('df-failed');
             common.showAllByClass('df-success');
+            common.showAllByClass('df-failed');
+            common.showAllByClass('df-warning');
             common.showAllByClass('df-unknown');
         }
     }

--- a/app/dashboard/static/js/app/buttons/common.js
+++ b/app/dashboard/static/js/app/buttons/common.js
@@ -117,6 +117,7 @@ define([
                 if (!target.hasAttribute('disabled')) {
                     hideAllByClass('df-failed');
                     showAllByClass('df-success');
+                    hideAllByClass('df-warning');
                     showAllByClass('df-unknown');
 
                     [].forEach.call(
@@ -126,6 +127,7 @@ define([
             case 'success-btn':
                 hideAllByClass('df-failed');
                 showAllByClass('df-success');
+                hideAllByClass('df-warning');
                 hideAllByClass('df-unknown');
                 break;
             case 'fail-cell':
@@ -133,6 +135,7 @@ define([
                 if (!target.hasAttribute('disabled')) {
                     showAllByClass('df-failed');
                     hideAllByClass('df-success');
+                    hideAllByClass('df-warning');
                     hideAllByClass('df-unknown');
 
                     [].forEach.call(
@@ -142,6 +145,25 @@ define([
             case 'fail-btn':
                 showAllByClass('df-failed');
                 hideAllByClass('df-success');
+                hideAllByClass('df-warning');
+                hideAllByClass('df-unknown');
+                break;
+            case 'warning-cell':
+                target = document.getElementById('warning-btn');
+                if (!target.hasAttribute('disabled')) {
+                    hideAllByClass('df-failed');
+                    hideAllByClass('df-success');
+                    showAllByClass('df-warning');
+                    hideAllByClass('df-unknown');
+
+                    [].forEach.call(
+                        target.parentElement.children, _makeActiveInactive);
+                }
+                break;
+            case 'warning-btn':
+                hideAllByClass('df-failed');
+                hideAllByClass('df-success');
+                showAllByClass('df-warning');
                 hideAllByClass('df-unknown');
                 break;
             case 'unknown-cell':
@@ -149,6 +171,7 @@ define([
                 if (!target.hasAttribute('disabled')) {
                     hideAllByClass('df-failed');
                     hideAllByClass('df-success');
+                    hideAllByClass('df-warning');
                     showAllByClass('df-unknown');
 
                     [].forEach.call(
@@ -158,11 +181,13 @@ define([
             case 'unknown-btn':
                 hideAllByClass('df-failed');
                 hideAllByClass('df-success');
+                hideAllByClass('df-warning');
                 showAllByClass('df-unknown');
                 break;
             default:
                 showAllByClass('df-failed');
                 showAllByClass('df-success');
+                showAllByClass('df-warning');
                 showAllByClass('df-unknown');
 
                 target = document.getElementById('all-btn');

--- a/app/dashboard/static/js/app/charts/passpie.js
+++ b/app/dashboard/static/js/app/charts/passpie.js
@@ -38,34 +38,43 @@ define([
         var counted;
         var failed;
         var passed;
+        var warning;
         var results;
-        var total;
         var unknown;
 
-        total = 0;
         failed = 0;
         passed = 0;
+        warning = 0;
         unknown = 0;
         counted = null;
 
         results = response.result;
         if (results.length > 0) {
             results.forEach(function(result) {
-                switch (result.status) {
+                var status;
+
+                if ((result.status == "PASS") && result.warnings)
+                    status = 'WARNING';
+                else
+                    status = result.status;
+
+                switch (status) {
                     case 'FAIL':
-                        failed = failed + 1;
+                        failed += 1;
                         break;
                     case 'PASS':
-                        passed = passed + 1;
+                        passed += 1;
+                        break;
+                    case 'WARNING':
+                        warning += 1;
                         break;
                     default:
-                        unknown = unknown + 1;
+                        unknown += 1;
                         break;
                 }
             });
 
-            total = passed + failed + unknown;
-            counted = [total, [passed, failed, unknown]];
+            counted = [results.length, [passed, warning, failed, unknown]];
         }
 
         return counted;
@@ -83,7 +92,7 @@ define([
             setup = {
                 values: data[1],
                 total: data[0],
-                chart: chart
+                chart: chart,
             };
 
             html.removeChildren(document.getElementById(settings.element));

--- a/app/dashboard/static/js/app/charts/pie.js
+++ b/app/dashboard/static/js/app/charts/pie.js
@@ -45,8 +45,8 @@ define([
             text: 'total reports'
         };
 
-        // pass, fail, unknown
-        color = ['#5cb85c', '#d9534f', '#f0ad4e'];
+        // pass, warning, fail, unknown
+        color = ['#5cb85c', '#f0ad4e', '#d9534f', '#777777'];
 
         piechart = function(selection) {
             var gArc;
@@ -100,6 +100,7 @@ define([
                     if (!ids) {
                         ids = {
                             'pass': '#success-cell',
+                            'warning': '#warning-cell',
                             'fail': '#fail-cell',
                             'unknown': '#unknown-cell',
                         };
@@ -108,6 +109,7 @@ define([
                     if (!titles) {
                         titles = {
                             'pass': 'Successful',
+                            'warning': 'Warning',
                             'fail': 'Failed',
                             'unknown': 'Unknown',
                         };
@@ -119,18 +121,24 @@ define([
                             p.sprintf(
                                 sTooltipFmt, titles['pass'], data.values[0]))
                         .css('border-bottom-color', color[0]);
+                    $(ids['warning'])
+                        .empty()
+                        .append(
+                            p.sprintf(
+                                sTooltipFmt, titles['warning'], data.values[1]))
+                        .css('border-bottom-color', color[1]);
                     $(ids['fail'])
                         .empty()
                         .append(
                             p.sprintf(
-                                sTooltipFmt, titles['fail'], data.values[1]))
-                        .css('border-bottom-color', color[1]);
+                                sTooltipFmt, titles['fail'], data.values[2]))
+                        .css('border-bottom-color', color[2]);
                     $(ids['unknown'])
                         .empty()
                         .append(
                             p.sprintf(
-                                sTooltipFmt, titles['unknown'], data.values[2]))
-                        .css('border-bottom-color', color[2]);
+                                sTooltipFmt, titles['unknown'], data.values[3]))
+                        .css('border-bottom-color', color[3]);
                 }
             });
         };

--- a/app/dashboard/static/js/app/components/test/view.js
+++ b/app/dashboard/static/js/app/components/test/view.js
@@ -39,12 +39,14 @@ define([
         buttonAll: document.getElementById('all-btn'),
         buttonFail: document.getElementById('fail-btn'),
         buttonSuccess: document.getElementById('success-btn'),
+        buttonWarning: document.getElementById('warning-btn'),
         buttonUnknown: document.getElementById('unknown-btn'),
         element: null,
         fileServer: null,
         lastPressedButton: null,
         hasFail: false,
         hasSuccess: false,
+        hasWarning: false,
         hasUnknown: false,
         results: null,
     };
@@ -69,7 +71,7 @@ define([
             result.defconfig_full;
 
         return dataIndex;
-    }
+    };
 
     kciView.createLabSection = function(lab) {
         var buttonNode;
@@ -145,6 +147,10 @@ define([
                 this.hasSuccess = true;
                 statusNode = html.success();
                 break;
+            case 'WARNING':
+                this.hasWarning = true;
+                statusNode = html.warning();
+                break;
             default:
                 this.hasUnknown = true;
                 statusNode = html.unknown();
@@ -152,7 +158,7 @@ define([
         }
         html.addClass(statusNode.firstElementChild, 'pull-right');
         return statusNode;
-    }
+    };
 
     kciView.addFilterClass = function(panelNode, status) {
         var filterClass;
@@ -163,6 +169,9 @@ define([
                 break;
             case 'PASS':
                 filterClass = 'df-success';
+                break;
+            case 'WARNING':
+                filterClass = 'df-warning';
                 break;
             default:
                 filterClass = 'df-unknown';
@@ -190,8 +199,6 @@ define([
         var hNode;
         var headingNode;
         var htmlLog;
-        var job;
-        var kernel;
         var kernelImage;
         var kernelImageSize;
         var labName;
@@ -207,10 +214,7 @@ define([
         var tooltipNode;
         var translatedURI;
         var txtLog;
-        var warnings;
 
-        job = result.job;
-        kernel = result.kernel;
         docId = result._id.$oid;
         serverURL = result.file_server_url;
         defconfigFull = result.defconfig_full;
@@ -218,7 +222,6 @@ define([
         buildEnv = result.build_environment;
         labName = result.lab_name;
         deviceType = result.device_type;
-        warnings = result.warnings;
         txtLog = result.boot_log;
         htmlLog = result.boot_log_html;
         kernelImage = result.kernel_image;
@@ -484,6 +487,10 @@ define([
             this.buttonSuccess.removeAttribute('disabled');
         }
 
+        if (this.hasWarning) {
+            this.buttonWarning.removeAttribute('disabled');
+        }
+
         if (this.hasUnknown) {
             this.buttonUnknown.removeAttribute('disabled');
         }
@@ -493,6 +500,8 @@ define([
         this.buttonSuccess.addEventListener(
             'click', commonBtns.showHideElements, true);
         this.buttonFail.addEventListener(
+            'click', commonBtns.showHideElements, true);
+        this.buttonWarning.addEventListener(
             'click', commonBtns.showHideElements, true);
         this.buttonUnknown.addEventListener(
             'click', commonBtns.showHideElements, true);

--- a/app/dashboard/static/js/app/tables/common.js
+++ b/app/dashboard/static/js/app/tables/common.js
@@ -121,6 +121,10 @@ define([
                 tooltipNode.setAttribute('title', defaults.fail);
                 tooltipNode.appendChild(html.fail());
                 break;
+            case 'WARNING':
+                tooltipNode.setAttribute('title', defaults.warning);
+                tooltipNode.appendChild(html.warning());
+                break;
             default:
                 tooltipNode.setAttribute('title', defaults.default);
                 tooltipNode.appendChild(html.unknown());

--- a/app/dashboard/static/js/app/tables/common.js
+++ b/app/dashboard/static/js/app/tables/common.js
@@ -121,10 +121,6 @@ define([
                 tooltipNode.setAttribute('title', defaults.fail);
                 tooltipNode.appendChild(html.fail());
                 break;
-            case 'OFFLINE':
-                tooltipNode.setAttribute('title', defaults.offline);
-                tooltipNode.appendChild(html.offline());
-                break;
             default:
                 tooltipNode.setAttribute('title', defaults.default);
                 tooltipNode.appendChild(html.unknown());

--- a/app/dashboard/static/js/app/tables/common.js
+++ b/app/dashboard/static/js/app/tables/common.js
@@ -1,8 +1,8 @@
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -61,44 +61,36 @@ define([
      * Create the actual count badge.
      *
      * @return {Element} A DOM element.
-    **/
-    function _countBadge(data, type, extraClasses, idStart) {
+     **/
+    function _countBadge(settings, type) {
         var classes;
         var iNode;
         var nodeId;
         var spanNode;
 
-        if (idStart && idStart.length > 0) {
-            nodeId = idStart;
-        } else {
-            nodeId = '';
-        }
-
         switch (type) {
-            case 'success':
-                nodeId = nodeId + 'success-count-' + data;
+            case 'pass':
                 classes = ['badge', 'alert-success', 'count-badge'];
                 break;
             case 'fail':
-                nodeId = nodeId + 'fail-count-' + data;
                 classes = ['badge', 'alert-danger', 'count-badge'];
                 break;
-            case 'unknown':
-                nodeId = nodeId + 'unknown-count-' + data;
+            case 'warning':
                 classes = ['badge', 'alert-warning', 'count-badge'];
                 break;
             case 'total':
-                nodeId = nodeId + 'total-count-' + data;
-                classes = ['badge', 'count-badge'];
-                break;
             default:
-                nodeId = nodeId + 'count-' + data;
                 classes = ['badge', 'count-badge'];
                 break;
         }
 
-        if (extraClasses && extraClasses.length > 0) {
-            classes = classes.concat(extraClasses);
+        nodeId = settings.idStart || '';
+        if (type)
+            nodeId += type + '-';
+        nodeId += 'count-' + settings.data;
+
+        if (settings.extraClasses && settings.extraClasses.length > 0) {
+            classes = classes.concat(settings.extraClasses);
         }
 
         spanNode = document.createElement('span');
@@ -107,7 +99,6 @@ define([
 
         iNode = document.createElement('i');
         iNode.className = 'fa fa-circle-o-notch fa-spin fa-fw count-content';
-
         spanNode.appendChild(iNode);
 
         return spanNode;
@@ -153,8 +144,8 @@ define([
      * @param {String} idStart: Head string for the id of the badge.
      * @return {Element} The badge node as an HTMLElement.
     **/
-    gTablesUtils.countBadge = function(data, type, extraClasses, idStart) {
-        return _countBadge(data, type, extraClasses, idStart);
+    gTablesUtils.countBadge = function(settings, badgeType=null) {
+        return _countBadge(settings, badgeType).outerHTML;
     };
 
     /**
@@ -167,56 +158,41 @@ define([
      * - extraClasses: Extra CSS classes to add to the badge.
      * - idStart: Head element for the id of the badge.
     **/
-    gTablesUtils.countAll = function(settings) {
+    gTablesUtils.countAll = function(settings, badgeTypes) {
         var aNode;
         var divNode;
-        var failNode;
         var rendered;
-        var successNode;
-        var totalNode;
-        var unknownNode;
+        var badges = [];
 
         if (settings.type === 'display') {
             divNode = document.createElement('div');
 
-            totalNode = _countBadge(
-                settings.data,
-                'total', settings.extraClasses, settings.idStart);
-            successNode = _countBadge(
-                settings.data,
-                'success', settings.extraClasses, settings.idStart);
-            failNode = _countBadge(
-                settings.data,
-                'fail', settings.extraClasses, settings.idStart);
-            unknownNode = _countBadge(
-                settings.data,
-                'unknown', settings.extraClasses, settings.idStart);
+            badgeTypes.forEach(function(badgeType) {
+                badges.push(_countBadge(settings, badgeType));
+            });
 
             if (settings.href) {
                 aNode = document.createElement('a');
                 aNode.className = 'clean-link';
                 aNode.setAttribute('href', settings.href);
 
-                aNode.appendChild(totalNode);
-                aNode.appendChild(successNode);
-                aNode.appendChild(failNode);
-                aNode.appendChild(unknownNode);
+                badges.forEach(function(badge) {
+                    aNode.appendChild(badge);
+                });
 
                 divNode.appendChild(aNode);
             } else {
-                divNode.appendChild(totalNode);
-                divNode.appendChild(successNode);
-                divNode.appendChild(failNode);
-                divNode.appendChild(unknownNode);
+                badges.forEach(function(badge) {
+                    divNode.appendChild(badge);
+                });
             }
 
             rendered = divNode.outerHTML;
 
             // Remove the nodes.
-            totalNode.remove();
-            successNode.remove();
-            failNode.remove();
-            unknownNode.remove();
+            badges.forEach(function(badge) {
+                badge.remove();
+            });
             if (aNode) {
                 aNode.remove();
             }

--- a/app/dashboard/static/js/app/tables/job.js
+++ b/app/dashboard/static/js/app/tables/job.js
@@ -46,7 +46,7 @@ define([
         settings.extraClasses = ['extra-margin'];
         settings.idStart = 'build-';
         return tcommon.countAll(settings, [
-            'total', 'pass', 'fail', 'warning',
+            'pass', 'warning', 'fail',
         ]);
     };
 

--- a/app/dashboard/static/js/app/tables/job.js
+++ b/app/dashboard/static/js/app/tables/job.js
@@ -38,7 +38,7 @@ define([
         settings.extraClasses = ['extra-margin'];
         settings.idStart = 'test-';
         return tcommon.countAll(settings, [
-            'total', 'pass', 'fail', 'warning',
+            'pass', 'warning', 'fail',
         ]);
     };
 

--- a/app/dashboard/static/js/app/tables/job.js
+++ b/app/dashboard/static/js/app/tables/job.js
@@ -37,13 +37,17 @@ define([
     gJobUtils.renderTestCount = function(settings) {
         settings.extraClasses = ['extra-margin'];
         settings.idStart = 'test-';
-        return tcommon.countAll(settings);
+        return tcommon.countAll(settings, [
+            'total', 'pass', 'fail', 'warning',
+        ]);
     };
 
     gJobUtils.renderBuildCount = function(settings) {
         settings.extraClasses = ['extra-margin'];
         settings.idStart = 'build-';
-        return tcommon.countAll(settings);
+        return tcommon.countAll(settings, [
+            'total', 'pass', 'fail', 'warning',
+        ]);
     };
 
     /**

--- a/app/dashboard/static/js/app/tables/soc.js
+++ b/app/dashboard/static/js/app/tables/soc.js
@@ -81,7 +81,7 @@ define([
             extraClasses: ['extra-margin'],
             idStart: 'test-'
         }, [
-            'total', 'pass', 'fail', 'warning',
+            'pass', 'warning', 'fail',
         ]);
     };
 

--- a/app/dashboard/static/js/app/tables/soc.js
+++ b/app/dashboard/static/js/app/tables/soc.js
@@ -70,9 +70,7 @@ define([
     };
 
     gSocTables.countBadge = function(settings) {
-        return tcommon.countBadge(
-            settings.data,
-            settings.type, settings.extraClasses, settings.idStart).outerHTML;
+        return tcommon.countBadge(settings);
     };
 
     gSocTables.renderTestCount = function(data, type, href) {
@@ -82,7 +80,9 @@ define([
             href: href,
             extraClasses: ['extra-margin'],
             idStart: 'test-'
-        });
+        }, [
+            'total', 'pass', 'fail', 'warning',
+        ]);
     };
 
     gSocTables.renderDetails = function(href, type, title) {

--- a/app/dashboard/static/js/app/tables/test.js
+++ b/app/dashboard/static/js/app/tables/test.js
@@ -51,7 +51,9 @@ define([
     gTestTable.renderTestCount = function(settings) {
         settings.extraClasses = ['extra-margin'];
         settings.idStart = 'test-';
-        return tcommon.countAll(settings);
+        return tcommon.countAll(settings, [
+            'total', 'pass', 'fail', 'warning',
+        ]);
     };
 
     return gTestTable;

--- a/app/dashboard/static/js/app/tables/test.js
+++ b/app/dashboard/static/js/app/tables/test.js
@@ -12,7 +12,6 @@ define([
     gStatusDefaults = {
         pass: 'Test executed successfully',
         fail: 'Test execution failed',
-        offline: 'Test offline',
         default: 'Test execution status unknown'
     };
 

--- a/app/dashboard/static/js/app/tables/test.js
+++ b/app/dashboard/static/js/app/tables/test.js
@@ -52,7 +52,7 @@ define([
         settings.extraClasses = ['extra-margin'];
         settings.idStart = 'test-';
         return tcommon.countAll(settings, [
-            'total', 'pass', 'fail', 'warning',
+            'pass', 'warning', 'fail',
         ]);
     };
 

--- a/app/dashboard/static/js/app/tables/test.js
+++ b/app/dashboard/static/js/app/tables/test.js
@@ -36,30 +36,6 @@ define([
         return tcommon.statusNode(status, gStatusDefaults);
     };
 
-    /**
-     * Function to render the case detail.
-     *
-     * @param {string} link: The href link to point to.
-     * @return {Element} The DOM element.
-    **/
-    gTestTable.detailsNode = function(link) {
-        var aNode;
-        var str;
-        var tooltipNode;
-
-        tooltipNode = html.tooltip();
-        tooltipNode.setAttribute('title', 'More info');
-
-        aNode = document.createElement('a');
-        str = link;
-        aNode.setAttribute('href', str);
-
-        aNode.appendChild(html.search());
-        tooltipNode.appendChild(aNode);
-
-        return tooltipNode;
-    };
-
     gTestTable.renderDate = function(date, type) {
         return tcommon.renderDate(date, type);
     };
@@ -68,35 +44,8 @@ define([
         return tcommon.renderDetails(href, type, title);
     };
 
-    gTestTable.countBadge = function(settings) {
-        return tcommon.countBadge(
-            settings.data,
-            settings.type, settings.extraClasses, settings.idStart).outerHTML;
-    };
-
-    gTestTable.renderCasesCount = function(data, type, id_str, href) {
-        return tcommon.countAll({
-            data: data,
-            type: type,
-            href: href,
-            extraClasses: ['extra-margin'],
-            idStart: id_str
-        });
-    };
-
     gTestTable.renderTree = function(tree, type, href) {
         return tcommon.renderTree(tree, type, href);
-    };
-
-    gTestTable.getCountFail = function(idStart) {
-        document.getElementById('cases-total-count-'+ idStart)
-            .innerHTML ='&infin;';
-        document.getElementById('cases-success-count-'+ idStart)
-            .innerHTML ='&infin;';
-        document.getElementById('cases-fail-count-'+ idStart)
-            .innerHTML ='&infin;';
-        document.getElementById('cases-unknown-count-'+ idStart)
-            .innerHTML ='&infin;';
     };
 
     gTestTable.renderTestCount = function(settings) {

--- a/app/dashboard/static/js/app/tables/test.js
+++ b/app/dashboard/static/js/app/tables/test.js
@@ -11,7 +11,8 @@ define([
 
     gStatusDefaults = {
         pass: 'Test executed successfully',
-        fail: 'Test execution failed',
+        fail: 'Test execution regressed',
+        warning: 'Test execution failed',
         default: 'Test execution status unknown'
     };
 

--- a/app/dashboard/static/js/app/utils/html.js
+++ b/app/dashboard/static/js/app/utils/html.js
@@ -211,8 +211,12 @@ define([
         return _status('label-danger', 'fa-exclamation-triangle', extraClass);
     };
 
+    html.warning = function(extraClass) {
+        return _status('label-warning', 'fa-close', extraClass);
+    };
+
     html.unknown = function(extraClass) {
-        return _status('label-warning', 'fa-question', extraClass);
+        return _status('label-default', 'fa-question', extraClass);
     };
 
     html.building = function(extraClass) {

--- a/app/dashboard/static/js/app/utils/html.js
+++ b/app/dashboard/static/js/app/utils/html.js
@@ -58,6 +58,24 @@ define([
         return htmlEntities[char];
     }
 
+    function _status(labelClass, symbolClass, extraClass) {
+        var frag;
+        var iNode;
+        var spanNode;
+
+        frag = document.createDocumentFragment();
+
+        spanNode = frag.appendChild(document.createElement('span'));
+        spanNode.className = 'label label-status ' + labelClass;
+        if (extraClass && extraClass.trim().length > 0) {
+            spanNode.className += ' ' + extraClass;
+        }
+        iNode = spanNode.appendChild(document.createElement('i'));
+        iNode.className = 'fa ' + symbolClass;
+
+        return frag;
+    }
+
     /**
      * Parse a string and HTML-escape its characters.
      *
@@ -127,10 +145,9 @@ define([
         return frag;
     };
 
-    html.test = function (extraClass) {
+    html.test = function () {
         var frag;
         var iNode;
-        var spanNode;
 
         frag = document.createDocumentFragment();
 
@@ -186,76 +203,20 @@ define([
         return frag;
     };
 
-    html.building = function(extraClass) {
-        var frag;
-        var iNode;
-        var spanNode;
-
-        frag = document.createDocumentFragment();
-
-        spanNode = frag.appendChild(document.createElement('span'));
-        spanNode.className = 'label label-info label-status';
-        if (extraClass && extraClass.trim().length > 0) {
-            spanNode.className += ' ' + extraClass;
-        }
-        iNode = spanNode.appendChild(document.createElement('i'));
-        iNode.className = 'fa fa-cogs';
-
-        return frag;
+    html.success = function(extraClass) {
+        return _status('label-success', 'fa-check', extraClass);
     };
 
     html.fail = function(extraClass) {
-        var frag;
-        var iNode;
-        var spanNode;
-
-        frag = document.createDocumentFragment();
-
-        spanNode = frag.appendChild(document.createElement('span'));
-        spanNode.className = 'label label-danger label-status';
-        if (extraClass && extraClass.trim().length > 0) {
-            spanNode.className += ' ' + extraClass;
-        }
-        iNode = spanNode.appendChild(document.createElement('i'));
-        iNode.className = 'fa fa-exclamation-triangle';
-
-        return frag;
-    };
-
-    html.success = function(extraClass) {
-        var frag;
-        var iNode;
-        var spanNode;
-
-        frag = document.createDocumentFragment();
-
-        spanNode = frag.appendChild(document.createElement('span'));
-        spanNode.className = 'label label-success label-status';
-        if (extraClass && extraClass.trim().length > 0) {
-            spanNode.className += ' ' + extraClass;
-        }
-        iNode = spanNode.appendChild(document.createElement('i'));
-        iNode.className = 'fa fa-check';
-
-        return frag;
+        return _status('label-danger', 'fa-exclamation-triangle', extraClass);
     };
 
     html.unknown = function(extraClass) {
-        var frag;
-        var iNode;
-        var spanNode;
+        return _status('label-warning', 'fa-question', extraClass);
+    };
 
-        frag = document.createDocumentFragment();
-
-        spanNode = frag.appendChild(document.createElement('span'));
-        spanNode.className = 'label label-warning label-status';
-        if (extraClass && extraClass.trim().length > 0) {
-            spanNode.className += ' ' + extraClass;
-        }
-        iNode = spanNode.appendChild(document.createElement('i'));
-        iNode.className = 'fa fa-question';
-
-        return frag;
+    html.building = function(extraClass) {
+        return _status('label-info', 'fa-cogs', extraClass);
     };
 
     html.tooltip = function() {

--- a/app/dashboard/static/js/app/utils/html.js
+++ b/app/dashboard/static/js/app/utils/html.js
@@ -258,24 +258,6 @@ define([
         return frag;
     };
 
-    html.offline = function(extraClass) {
-        var frag;
-        var iNode;
-        var spanNode;
-
-        frag = document.createDocumentFragment();
-
-        spanNode = frag.appendChild(document.createElement('span'));
-        spanNode.className = 'label label-info label-status';
-        if (extraClass && extraClass.trim().length > 0) {
-            spanNode.className += ' ' + extraClass;
-        }
-        iNode = spanNode.appendChild(document.createElement('i'));
-        iNode.className = 'fa fa-power-off';
-
-        return frag;
-    };
-
     html.tooltip = function() {
         var element;
 

--- a/app/dashboard/static/js/app/view-builds-id.2020.9.js
+++ b/app/dashboard/static/js/app/view-builds-id.2020.9.js
@@ -498,7 +498,7 @@ require([
         var spanNode;
         var systemMap;
         var systemMapSize;
-        var str;
+        var status;
         var textOffset;
         var tooltipNode;
         var translatedUri;
@@ -567,6 +567,11 @@ require([
             txtSize = results.vmlinux_text_size;
             systemMap = results.system_map;
             systemMapSize = results.system_map_size;
+
+            if ((results.status == "PASS") && results.warnings)
+                status = "WARNING";
+            else
+                status = results.status;
 
             // The body title.
             docFrag = document.createDocumentFragment();
@@ -787,7 +792,7 @@ require([
             // Status.
             docFrag = document.createDocumentFragment();
             tooltipNode = docFrag.appendChild(html.tooltip());
-            switch (results.status) {
+            switch (status) {
                 case 'PASS':
                     tooltipNode.setAttribute('title', 'Build completed');
                     tooltipNode.appendChild(html.success());
@@ -795,6 +800,10 @@ require([
                 case 'FAIL':
                     tooltipNode.setAttribute('title', 'Build failed');
                     tooltipNode.appendChild(html.fail());
+                    break;
+                case 'WARNING':
+                    tooltipNode.setAttribute('title', 'Build had warnings');
+                    tooltipNode.appendChild(html.warning());
                     break;
                 default:
                     tooltipNode.setAttribute('title', 'Unknown status');

--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.9.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.9.js
@@ -95,6 +95,12 @@ require([
             }
         );
         Array.prototype.forEach.call(
+            document.getElementsByClassName('df-warning'),
+            function(element) {
+                element.style.setProperty('display', 'none');
+            }
+        );
+        Array.prototype.forEach.call(
             document.getElementsByClassName('df-unknown'),
             function(element) {
                 element.style.setProperty('display', 'none');
@@ -205,17 +211,15 @@ require([
         var hNode;
         var hasFailed;
         var hasSuccess;
+        var hasWarning;
         var hasUnknown;
         var headingNode;
         var infoNode;
-        var job;
-        var kernel;
         var panelNode;
         var results;
         var rowNode;
         var smallNode;
         var status;
-        var statusNode;
         var tooltipNode;
         var translatedURI;
         var warnErrCount;
@@ -227,6 +231,7 @@ require([
 
         hasFailed = false;
         hasSuccess = false;
+        hasWarning = false;
         hasUnknown = false;
         results = response.result;
 
@@ -273,8 +278,6 @@ require([
         function _parseResult(result, idx) {
             docId = result._id.$oid;
             defconfigFull = result.defconfig_full;
-            job = result.job;
-            kernel = result.kernel;
             arch = result.arch;
             compiler = result.build_environment;
             fileServerURL = result.file_server_url;
@@ -283,6 +286,9 @@ require([
             warningsCount = result.warnings;
             status = result.status;
             collapseId = 'collapse-defconf' + idx;
+
+            if ((status == "PASS") && warningsCount)
+                status = "WARNING";
 
             if (fileServerURL === null || fileServerURL === undefined) {
                 fileServerURL = gFileServer;
@@ -333,17 +339,22 @@ require([
             switch (status) {
                 case 'FAIL':
                     hasFailed = true;
-                    statusNode = hNode.appendChild(html.fail('pull-right'));
+                    hNode.appendChild(html.fail('pull-right'));
                     cls = 'df-failed';
                     break;
                 case 'PASS':
                     hasSuccess = true;
-                    statusNode = hNode.appendChild(html.success('pull-right'));
+                    hNode.appendChild(html.success('pull-right'));
                     cls = 'df-success';
+                    break;
+                case 'WARNING':
+                    hasWarning = true;
+                    hNode.appendChild(html.warning('pull-right'));
+                    cls = 'df-warning';
                     break;
                 default:
                     hasUnknown = true;
-                    statusNode = hNode.appendChild(html.unknown('pull-right'));
+                    hNode.appendChild(html.unknown('pull-right'));
                     cls = 'df-unknown';
                     break;
             }
@@ -679,6 +690,10 @@ require([
             if (hasSuccess) {
                 document
                     .getElementById('success-btn').removeAttribute('disabled');
+            }
+            if (hasWarning) {
+                document
+                    .getElementById('warning-btn').removeAttribute('disabled');
             }
             if (hasUnknown) {
                 document
@@ -1121,6 +1136,11 @@ require([
                 name: 'style',
                 value: html.attrBySelector('.df-failed', 'style')
             };
+            pageState['.df-warning'] = {
+                type: 'attr',
+                name: 'style',
+                value: html.attrBySelector('.df-warning', 'style')
+            };
             pageState['.df-unknown'] = {
                 type: 'attr',
                 name: 'style',
@@ -1140,6 +1160,11 @@ require([
                 type: 'class',
                 name: 'class',
                 value: html.attrById('fail-btn', 'class')
+            };
+            pageState['#warning-btn'] = {
+                type: 'class',
+                name: 'class',
+                value: html.attrById('warning-btn', 'class')
             };
             pageState['#unknown-btn'] = {
                 type: 'class',

--- a/app/dashboard/static/js/app/view-jobs-all.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-all.2020.9.js
@@ -181,21 +181,23 @@ require([
                 query: qHead
             });
 
-            // Get total tests count.
-            opId = 'test-total-count-';
+            // Get successful tests count.
+            opId = 'test-pass-count-';
             opId += opIdTail;
+            qHead = 'status=PASS&';
+            qHead += qStr;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
                 document: 'test_case',
-                query: qStr
+                query: qHead
             });
 
-            // Get successful tests count.
-            opId = 'test-pass-count-';
+            // Get warnings test reports count.
+            opId = 'test-warning-count-';
             opId += opIdTail;
-            qHead = 'status=PASS&';
+            qHead = 'status=FAIL&regression_id=null&';
             qHead += qStr;
             batchOps.push({
                 method: 'GET',
@@ -214,19 +216,6 @@ require([
                 resource: 'count',
                 document: 'test_regression',
                 query: qStr
-            });
-
-            // Get unknown test reports count.
-            opId = 'test-warning-count-';
-            opId += opIdTail;
-            qHead = 'status=FAIL&status=SKIP&regression_id=null&';
-            qHead += qStr;
-            batchOps.push({
-                method: 'GET',
-                operation_id: opId,
-                resource: 'count',
-                document: 'test_case',
-                query: qHead
             });
         }
 

--- a/app/dashboard/static/js/app/view-jobs-all.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-all.2020.9.js
@@ -142,21 +142,23 @@ require([
 
             opIdTail = job + '-' + branch;
 
-            // Get total build count.
-            opId = 'build-total-count-';
+            // Get successful build count.
+            opId = 'build-pass-count-';
             opId += opIdTail;
+            qHead = 'status=PASS&lt=warnings,1&';
+            qHead += qStr;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
                 document: 'build',
-                query: qStr
+                query: qHead
             });
 
-            // Get successful build count.
-            opId = 'build-pass-count-';
+            // Get warnings build count.
+            opId = 'build-warning-count-';
             opId += opIdTail;
-            qHead = 'status=PASS&';
+            qHead = 'status=PASS&gte=warnings,1&';
             qHead += qStr;
             batchOps.push({
                 method: 'GET',
@@ -170,19 +172,6 @@ require([
             opId = 'build-fail-count-';
             opId += opIdTail;
             qHead = 'status=FAIL&';
-            qHead += qStr;
-            batchOps.push({
-                method: 'GET',
-                operation_id: opId,
-                resource: 'count',
-                document: 'build',
-                query: qHead
-            });
-
-            // Get unknown build count.
-            opId = 'build-warning-count-';
-            opId += opIdTail;
-            qHead = 'status=UNKNOWN&';
             qHead += qStr;
             batchOps.push({
                 method: 'GET',

--- a/app/dashboard/static/js/app/view-jobs-all.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-all.2020.9.js
@@ -140,9 +140,7 @@ require([
                 'git_branch': branch,
             });
 
-            opIdTail = job;
-            opIdTail += '-';
-            opIdTail += branch;
+            opIdTail = job + '-' + branch;
 
             // Get total build count.
             opId = 'build-total-count-';
@@ -156,7 +154,7 @@ require([
             });
 
             // Get successful build count.
-            opId = 'build-success-count-';
+            opId = 'build-pass-count-';
             opId += opIdTail;
             qHead = 'status=PASS&';
             qHead += qStr;
@@ -182,7 +180,7 @@ require([
             });
 
             // Get unknown build count.
-            opId = 'build-unknown-count-';
+            opId = 'build-warning-count-';
             opId += opIdTail;
             qHead = 'status=UNKNOWN&';
             qHead += qStr;
@@ -206,7 +204,7 @@ require([
             });
 
             // Get successful tests count.
-            opId = 'test-success-count-';
+            opId = 'test-pass-count-';
             opId += opIdTail;
             qHead = 'status=PASS&';
             qHead += qStr;
@@ -230,7 +228,7 @@ require([
             });
 
             // Get unknown test reports count.
-            opId = 'test-unknown-count-';
+            opId = 'test-warning-count-';
             opId += opIdTail;
             qHead = 'status=FAIL&status=SKIP&regression_id=null&';
             qHead += qStr;

--- a/app/dashboard/static/js/app/view-jobs-job-branch.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-job-branch.2020.9.js
@@ -180,21 +180,23 @@ require([
                 'git_branch': gBranchName,
             });
 
-            // Get total build count.
-            opId = 'build-total-count-';
+            // Get the successful build count.
+            opId = 'build-pass-count-';
             opId += kernel;
+            qHead = 'status=PASS&lt=warnings,1&';
+            qHead += queryStr;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
                 document: 'build',
-                query: queryStr
+                query: qHead
             });
 
-            // Get the successful build count.
-            opId = 'build-pass-count-';
+            // Get warnings build count.
+            opId = 'build-warning-count-';
             opId += kernel;
-            qHead = 'status=PASS&';
+            qHead = 'status=PASS&gte=warnings,1&';
             qHead += queryStr;
             batchOps.push({
                 method: 'GET',
@@ -208,19 +210,6 @@ require([
             opId = 'build-fail-count-';
             opId += kernel;
             qHead = 'status=FAIL&';
-            qHead += queryStr;
-            batchOps.push({
-                method: 'GET',
-                operation_id: opId,
-                resource: 'count',
-                document: 'build',
-                query: qHead
-            });
-
-            // Get unknown build count.
-            opId = 'build-warning-count-';
-            opId += kernel;
-            qHead = 'status=UNKNOWN&';
             qHead += queryStr;
             batchOps.push({
                 method: 'GET',

--- a/app/dashboard/static/js/app/view-jobs-job-branch.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-job-branch.2020.9.js
@@ -192,7 +192,7 @@ require([
             });
 
             // Get the successful build count.
-            opId = 'build-success-count-';
+            opId = 'build-pass-count-';
             opId += kernel;
             qHead = 'status=PASS&';
             qHead += queryStr;
@@ -218,7 +218,7 @@ require([
             });
 
             // Get unknown build count.
-            opId = 'build-unknown-count-';
+            opId = 'build-warning-count-';
             opId += kernel;
             qHead = 'status=UNKNOWN&';
             qHead += queryStr;
@@ -242,7 +242,7 @@ require([
             });
 
             // Get successful tests count.
-            opId = 'test-success-count-';
+            opId = 'test-pass-count-';
             opId += kernel;
             qHead = 'status=PASS&';
             qHead += queryStr;
@@ -266,7 +266,7 @@ require([
             });
 
             // Get unknown test reports count.
-            opId = 'test-unknown-count-';
+            opId = 'test-warning-count-';
             opId += kernel;
             qHead = 'status=FAIL&status=SKIP&regression_id=null&';
             qHead += queryStr;

--- a/app/dashboard/static/js/app/view-jobs-job-branch.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-job-branch.2020.9.js
@@ -219,21 +219,23 @@ require([
                 query: qHead
             });
 
-            // Get total tests count.
-            opId = 'test-total-count-';
+            // Get successful tests count.
+            opId = 'test-pass-count-';
             opId += kernel;
+            qHead = 'status=PASS&';
+            qHead += queryStr;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
                 document: 'test_case',
-                query: queryStr
+                query: qHead
             });
 
-            // Get successful tests count.
-            opId = 'test-pass-count-';
+            // Get warning test reports count.
+            opId = 'test-warning-count-';
             opId += kernel;
-            qHead = 'status=PASS&';
+            qHead = 'status=FAIL&regression_id=null&';
             qHead += queryStr;
             batchOps.push({
                 method: 'GET',
@@ -252,19 +254,6 @@ require([
                 resource: 'count',
                 document: 'test_regression',
                 query: queryStr
-            });
-
-            // Get unknown test reports count.
-            opId = 'test-warning-count-';
-            opId += kernel;
-            qHead = 'status=FAIL&status=SKIP&regression_id=null&';
-            qHead += queryStr;
-            batchOps.push({
-                method: 'GET',
-                operation_id: opId,
-                resource: 'count',
-                document: 'test_case',
-                query: qHead
             });
         }
 

--- a/app/dashboard/static/js/app/view-jobs-job.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-job.2020.9.js
@@ -178,21 +178,23 @@ require([
 
             opIdTail = result.kernel + '-' + result.git_branch;
 
-            // Get total build count.
-            opId = 'build-total-count-';
+            // Get the successful build count.
+            opId = 'build-pass-count-';
             opId += opIdTail;
+            qHead = 'status=PASS&lt=warnings,1&';
+            qHead += queryStr;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
                 document: 'build',
-                query: queryStr
+                query: qHead
             });
 
-            // Get the successful build count.
-            opId = 'build-pass-count-';
+            // Get warnings build count.
+            opId = 'build-warning-count-';
             opId += opIdTail;
-            qHead = 'status=PASS&';
+            qHead = 'status=PASS&gte=warnings,1&';
             qHead += queryStr;
             batchOps.push({
                 method: 'GET',
@@ -206,19 +208,6 @@ require([
             opId = 'build-fail-count-';
             opId += opIdTail;
             qHead = 'status=FAIL&';
-            qHead += queryStr;
-            batchOps.push({
-                method: 'GET',
-                operation_id: opId,
-                resource: 'count',
-                document: 'build',
-                query: qHead
-            });
-
-            // Get unknown build count.
-            opId = 'build-warning-count-';
-            opId += opIdTail;
-            qHead = 'status=UNKNOWN&';
             qHead += queryStr;
             batchOps.push({
                 method: 'GET',

--- a/app/dashboard/static/js/app/view-jobs-job.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-job.2020.9.js
@@ -217,21 +217,23 @@ require([
                 query: qHead
             });
 
-            // Get total tests count.
-            opId = 'test-total-count-';
+            // Get successful tests count.
+            opId = 'test-pass-count-';
             opId += opIdTail;
+            qHead = 'status=PASS&';
+            qHead += queryStr;
             batchOps.push({
                 method: 'GET',
                 operation_id: opId,
                 resource: 'count',
                 document: 'test_case',
-                query: queryStr
+                query: qHead
             });
 
-            // Get successful tests count.
-            opId = 'test-pass-count-';
+            // Get unknown test reports count.
+            opId = 'test-warning-count-';
             opId += opIdTail;
-            qHead = 'status=PASS&';
+            qHead = 'status=FAIL&regression_id=null&';
             qHead += queryStr;
             batchOps.push({
                 method: 'GET',
@@ -250,19 +252,6 @@ require([
                 resource: 'count',
                 document: 'test_regression',
                 query: queryStr
-            });
-
-            // Get unknown test reports count.
-            opId = 'test-warning-count-';
-            opId += opIdTail;
-            qHead = 'status=FAIL&status=SKIP&regression_id=null&';
-            qHead += queryStr;
-            batchOps.push({
-                method: 'GET',
-                operation_id: opId,
-                resource: 'count',
-                document: 'test_case',
-                query: qHead
             });
         }
 

--- a/app/dashboard/static/js/app/view-jobs-job.2020.9.js
+++ b/app/dashboard/static/js/app/view-jobs-job.2020.9.js
@@ -190,7 +190,7 @@ require([
             });
 
             // Get the successful build count.
-            opId = 'build-success-count-';
+            opId = 'build-pass-count-';
             opId += opIdTail;
             qHead = 'status=PASS&';
             qHead += queryStr;
@@ -216,7 +216,7 @@ require([
             });
 
             // Get unknown build count.
-            opId = 'build-unknown-count-';
+            opId = 'build-warning-count-';
             opId += opIdTail;
             qHead = 'status=UNKNOWN&';
             qHead += queryStr;
@@ -240,7 +240,7 @@ require([
             });
 
             // Get successful tests count.
-            opId = 'test-success-count-';
+            opId = 'test-pass-count-';
             opId += opIdTail;
             qHead = 'status=PASS&';
             qHead += queryStr;
@@ -264,7 +264,7 @@ require([
             });
 
             // Get unknown test reports count.
-            opId = 'test-unknown-count-';
+            opId = 'test-warning-count-';
             opId += opIdTail;
             qHead = 'status=FAIL&status=SKIP&regression_id=null&';
             qHead += queryStr;

--- a/app/dashboard/static/js/app/view-socs-all.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-all.2020.5.js
@@ -299,7 +299,6 @@ require([
             if (type === 'display') {
                 rendered = tsoc.countBadge({
                     data: data,
-                    type: 'default',
                     idStart: 'boards-',
                     extraClasses: ['boards-count-badge']
                 });
@@ -322,7 +321,6 @@ require([
             if (type === 'display') {
                 rendered = tsoc.countBadge({
                     data: data,
-                    type: 'default',
                     idStart: 'test-',
                     extraClasses: ['test-count-badge']
                 });
@@ -345,7 +343,6 @@ require([
             if (type === 'display') {
                 rendered = tsoc.countBadge({
                     data: data,
-                    type: 'default',
                     idStart: 'labs-',
                     extraClasses: ['labs-count-badge']
                 });

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.9.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.9.js
@@ -146,7 +146,7 @@ require([
         gPanel.draw();
     }
 
-    function createLabResultsCount(total, pass, fail, unknown) {
+    function createLabResultsCount(pass, fail, regression) {
         var docFrag;
         var smallNode;
         var spanNode;
@@ -156,29 +156,30 @@ require([
         tooltipNode = docFrag.appendChild(html.tooltip());
         html.addClass(tooltipNode, 'default-cursor');
         tooltipNode.title =
-            "Total, passed, regressions and unknown test results for this lab";
+            "Success, failure and regression results for this lab";
 
         smallNode = tooltipNode.appendChild(document.createElement('small'));
-        smallNode.appendChild(document.createTextNode(
-            '(' + format.number(total)));
+        smallNode.appendChild(document.createTextNode('('));
         smallNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
 
         spanNode = smallNode.appendChild(document.createElement('span'));
         spanNode.className = 'green-font';
-        spanNode.appendChild(document.createTextNode(format.number(pass)));
-
-        smallNode.insertAdjacentHTML('beforeend', '&nbsp;/&nbsp;');
-
-        spanNode = smallNode.appendChild(document.createElement('span'));
-        spanNode.className = 'red-font';
-        spanNode.appendChild(document.createTextNode(format.number(fail)));
+        spanNode.appendChild(
+            document.createTextNode(format.number(pass)));
 
         smallNode.insertAdjacentHTML('beforeend', '&nbsp;/&nbsp;');
 
         spanNode = smallNode.appendChild(document.createElement('span'));
         spanNode.className = 'yellow-font';
         spanNode.appendChild(
-            document.createTextNode(format.number(unknown)));
+            document.createTextNode(format.number(fail)));
+
+        smallNode.insertAdjacentHTML('beforeend', '&nbsp;/&nbsp;');
+
+        spanNode = smallNode.appendChild(document.createElement('span'));
+        spanNode.className = 'red-font';
+        spanNode.appendChild(document.createTextNode(
+            format.number(regression)));
 
         smallNode.appendChild(document.createTextNode(')'));
 
@@ -204,8 +205,8 @@ require([
 
             html.replaceContent(
                 document.getElementById('test-count-' + lab),
-                createLabResultsCount(res['total'], res['success'],
-                                      res['regressions'], res['unknown'])
+                createLabResultsCount(res['success'], res['failure'],
+                                      res['regression'])
             );
         });
     }
@@ -377,14 +378,6 @@ require([
 
             batchOps.push({
                 method: 'GET',
-                operation_id: [lab, 'total'],
-                resource: 'count',
-                document: 'test_case',
-                query: qStr,
-            });
-
-            batchOps.push({
-                method: 'GET',
                 operation_id: [lab, 'success'],
                 resource: 'count',
                 document: 'test_case',
@@ -393,18 +386,18 @@ require([
 
             batchOps.push({
                 method: 'GET',
-                operation_id: [lab, 'regressions'],
+                operation_id: [lab, 'failure'],
                 resource: 'count',
-                document: 'test_regression',
-                query: qStr,
+                document: 'test_case',
+                query: qStr + '&status=FAIL&regression_id=null',
             });
 
             batchOps.push({
                 method: 'GET',
-                operation_id: [lab, 'unknown'],
+                operation_id: [lab, 'regression'],
                 resource: 'count',
-                document: 'test_case',
-                query: qStr + '&status=FAIL&status=SKIP&regression_id=null',
+                document: 'test_regression',
+                query: qStr,
             });
         }
 

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.9.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.9.js
@@ -196,10 +196,11 @@ define([
             var results = response.result;
             var total = results[0].result[0].count;
             var pass = results[1].result[0].count;
-            var regressions = results[2].result[0].count;
-            var unknown = results[3].result[0].count;
+            var fail = results[2].result[0].count;
+            var regressions = results[3].result[0].count;
+            var unknown = results[4].result[0].count;
 
-            return [total, [pass, regressions, unknown]];
+            return [total, [pass, fail, regressions, unknown]];
         }
 
         chart.testpie({
@@ -223,7 +224,6 @@ define([
     }
 
     function updatePlansTable(results) {
-
         var columns;
 
         function _testColumnTitle() {
@@ -231,7 +231,7 @@ define([
 
             tooltipNode = html.tooltip();
             tooltipNode.setAttribute(
-                'title', 'Total/Successful/Regressions/Other test results');
+                'title', 'Pass/Fail/Regression test results');
             tooltipNode.appendChild(
                 document.createTextNode('Test Results'));
 
@@ -239,7 +239,7 @@ define([
         }
 
         function _renderTestCount(data, type) {
-            return ttest.renderTestCount({data: data, type: type})
+            return ttest.renderTestCount({data: data, type: type});
         }
 
         function _renderPlanStatus(data, type) {
@@ -275,7 +275,8 @@ define([
                 className: 'pull-center',
                 render: _renderPlanStatus,
             },
-        ]
+        ];
+
         gPlansTable
             .data(results)
             .columns(columns)
@@ -298,7 +299,7 @@ define([
             node.appendChild(ttest.statusNode(status));
         }
 
-        response.result.forEach(parseBatchData)
+        response.result.forEach(parseBatchData);
     }
 
     function getBatchStatusFailed() {
@@ -312,7 +313,7 @@ define([
                 document.createTextNode(data.result[0].count));
         }
 
-        response.result.forEach(parseBatchData)
+        response.result.forEach(parseBatchData);
     }
 
     function getBatchStatus(results) {
@@ -342,13 +343,13 @@ define([
         }
 
         batchOps = [];
-        results.forEach(createBatchOp)
+        results.forEach(createBatchOp);
         deferred = request.post(
             '/_ajax/batch', JSON.stringify({batch: batchOps}));
 
         $.when(deferred)
             .fail(error.error, getBatchStatusFailed)
-            .done(getBatchStatusDone)
+            .done(getBatchStatusDone);
     }
 
     function getBatchCountFailed() {
@@ -410,13 +411,13 @@ define([
         }
 
         batchOps = [];
-        results.forEach(createBatchOp)
+        results.forEach(createBatchOp);
         deferred = request.post(
             '/_ajax/batch', JSON.stringify({batch: batchOps}));
 
         $.when(deferred)
             .fail(error.error, getBatchCountFailed)
-            .done(getBatchCountDone)
+            .done(getBatchCountDone);
     }
 
     function detailsFailed() {
@@ -431,7 +432,7 @@ define([
     function getPlansDone(response) {
         if (response.result.length === 0) {
             getPlansFailed();
-            return
+            return;
         }
 
         updateDetails(response.result[0]);
@@ -465,7 +466,7 @@ define([
             ],
         };
 
-        deferred = request.get('/_ajax/test/group', data)
+        deferred = request.get('/_ajax/test/group', data);
         $.when(deferred)
             .fail(error.error, getPlansFailed)
             .done(getPlansDone);
@@ -482,7 +483,7 @@ define([
             'mach': gSoc
         });
 
-        batchOps = []
+        batchOps = [];
 
         /* Total number of test cases */
         batchOps.push({
@@ -502,6 +503,15 @@ define([
             query: qStr + '&status=PASS',
         });
 
+        /* Number of unknown test results */
+        batchOps.push({
+            method: 'GET',
+            operation_id: 'test-warning-count',
+            resource: 'count',
+            document: 'test_case',
+            query: qStr + '&status=FAIL&regression_id=null',
+        });
+
         /* Number of test case regressions */
         batchOps.push({
             method: 'GET',
@@ -517,7 +527,7 @@ define([
             operation_id: 'test-unknown-count',
             resource: 'count',
             document: 'test_case',
-            query: qStr + '&status=FAIL&status=SKIP&regression_id=null',
+            query: qStr + '&status=SKIP',
         });
 
         deferred = request.post(
@@ -525,7 +535,7 @@ define([
 
         $.when(deferred)
             .fail(error.error, chartCountFailed)
-            .done(updateChart)
+            .done(updateChart);
     }
 
     if (document.getElementById('job-name') !== null) {

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.9.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.9.js
@@ -384,7 +384,7 @@ define([
             /* Number of passing test cases */
             batchOps.push({
                 method: 'GET',
-                operation_id: 'test-success-count-' + plan,
+                operation_id: 'test-pass-count-' + plan,
                 resource: 'count',
                 document: 'test_case',
                 query: qStr + '&status=PASS',
@@ -402,7 +402,7 @@ define([
             /* Number of unknown test results */
             batchOps.push({
                 method: 'GET',
-                operation_id: 'test-unknown-count-' + plan,
+                operation_id: 'test-warning-count-' + plan,
                 resource: 'count',
                 document: 'test_case',
                 query: qStr + '&status=FAIL&status=SKIP&regression_id=null',

--- a/app/dashboard/static/js/app/view-socs-soc-job.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job.2020.5.js
@@ -4,7 +4,7 @@
  * Copyright (C) 2020 Collabora Limited
  * Author: Alexandra Pereira <alexandra.pereira@collabora.com>
  * Author: Guillaume Tucker <guillaume.tucker@collabora.com>
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -182,7 +182,7 @@ require([
             });
 
             batchOps.push({
-                operation_id: 'test-success-count-' + kernel,
+                operation_id: 'test-pass-count-' + kernel,
                 method: 'GET',
                 resource: 'count',
                 document: 'test_case',
@@ -198,7 +198,7 @@ require([
             });
 
             batchOps.push({
-                operation_id: 'test-unknown-count-' + kernel,
+                operation_id: 'test-warning-count-' + kernel,
                 method: 'GET',
                 resource: 'count',
                 document: 'test_case',

--- a/app/dashboard/static/js/app/view-socs-soc-job.2020.5.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job.2020.5.js
@@ -170,16 +170,8 @@ require([
         batchOps = [];
 
         function _prepareBatchOps(result) {
-            var kernel = result.kernel
+            var kernel = result.kernel;
             var filter = '&kernel=' + kernel;
-
-            batchOps.push({
-                operation_id: 'test-total-count-' + kernel,
-                method: 'GET',
-                resource: 'count',
-                document: 'test_case',
-                query: gQueryStr + filter
-            });
 
             batchOps.push({
                 operation_id: 'test-pass-count-' + kernel,
@@ -190,20 +182,20 @@ require([
             });
 
             batchOps.push({
-                operation_id: 'test-fail-count-' + kernel,
-                method: 'GET',
-                resource: 'count',
-                document: 'test_regression',
-                query: gQueryStr + filter
-            });
-
-            batchOps.push({
                 operation_id: 'test-warning-count-' + kernel,
                 method: 'GET',
                 resource: 'count',
                 document: 'test_case',
                 query: gQueryStr +
-                    '&status=FAIL&status=SKIP&regression_id=null' + filter
+                    '&status=FAIL&regression_id=null' + filter
+            });
+
+            batchOps.push({
+                operation_id: 'test-fail-count-' + kernel,
+                method: 'GET',
+                resource: 'count',
+                document: 'test_regression',
+                query: gQueryStr + filter
             });
         }
 

--- a/app/dashboard/static/js/app/view-socs-soc.2020.6.js
+++ b/app/dashboard/static/js/app/view-socs-soc.2020.6.js
@@ -183,7 +183,7 @@ require([
 
             batchOps.push({
                 method: 'GET',
-                operation_id: 'test-success-count-' + job,
+                operation_id: 'test-pass-count-' + job,
                 resource: 'count',
                 document: 'test_case',
                 query: queryStr + '&status=PASS' + filter
@@ -199,7 +199,7 @@ require([
 
             batchOps.push({
                 method: 'GET',
-                operation_id: 'test-unknown-count-' + job,
+                operation_id: 'test-warning-count-' + job,
                 resource: 'count',
                 document: 'test_case',
                 query: queryStr +

--- a/app/dashboard/static/js/app/view-socs-soc.2020.6.js
+++ b/app/dashboard/static/js/app/view-socs-soc.2020.6.js
@@ -175,14 +175,6 @@ require([
 
             batchOps.push({
                 method: 'GET',
-                operation_id: 'test-total-count-' + job,
-                resource: 'count',
-                document: 'test_case',
-                query: queryStr + filter
-            });
-
-            batchOps.push({
-                method: 'GET',
                 operation_id: 'test-pass-count-' + job,
                 resource: 'count',
                 document: 'test_case',
@@ -191,19 +183,19 @@ require([
 
             batchOps.push({
                 method: 'GET',
-                operation_id: 'test-fail-count-' + job,
-                resource: 'count',
-                document: 'test_regression',
-                query: queryStr + filter
-            });
-
-            batchOps.push({
-                method: 'GET',
                 operation_id: 'test-warning-count-' + job,
                 resource: 'count',
                 document: 'test_case',
                 query: queryStr +
-                    '&status=FAIL&status=SKIP&regression_id=null' + filter
+                    '&status=FAIL&regression_id=null' + filter
+            });
+
+            batchOps.push({
+                method: 'GET',
+                operation_id: 'test-fail-count-' + job,
+                resource: 'count',
+                document: 'test_regression',
+                query: queryStr + filter
             });
         }
 
@@ -282,7 +274,7 @@ require([
 
             tooltipNode = html.tooltip();
             tooltipNode.setAttribute(
-                'title', 'Total/Successful/Regressions/Other results');
+                'title', 'Pass/Fail/Regression results');
             tooltipNode.appendChild(
                 document.createTextNode('Latest Test Results'));
 
@@ -290,8 +282,6 @@ require([
         }
 
         results = response.result;
-        console.log("results:")
-        console.log(results)
         if (results.length > 0) {
             columns = [
                 {

--- a/app/dashboard/static/js/app/view-tests-case-id.2020.9.js
+++ b/app/dashboard/static/js/app/view-tests-case-id.2020.9.js
@@ -134,6 +134,8 @@ require([
             status = 'PASS';
         else if (results.regression_id)
             status = 'FAIL';
+        else if (results.status == 'FAIL')
+            status = 'WARNING';
         else
             status = 'UNKNOWN';
 

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.9.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.9.js
@@ -180,7 +180,7 @@ require([
         gPanel.draw();
     }
 
-    function createLabResultsCount(total, pass, fail, unknown) {
+    function createLabResultsCount(pass, fail, regression) {
         var docFrag;
         var smallNode;
         var spanNode;
@@ -190,29 +190,29 @@ require([
         tooltipNode = docFrag.appendChild(html.tooltip());
         html.addClass(tooltipNode, 'default-cursor');
         tooltipNode.title =
-            "Total, passed, regressions and unknown test results for this lab";
+            "Success, failure and regression results for this lab";
 
         smallNode = tooltipNode.appendChild(document.createElement('small'));
-        smallNode.appendChild(document.createTextNode(
-            '(' + format.number(total)));
-        smallNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
+        smallNode.appendChild(document.createTextNode('('));
 
         spanNode = smallNode.appendChild(document.createElement('span'));
         spanNode.className = 'green-font';
-        spanNode.appendChild(document.createTextNode(format.number(pass)));
-
-        smallNode.insertAdjacentHTML('beforeend', '&nbsp;/&nbsp;');
-
-        spanNode = smallNode.appendChild(document.createElement('span'));
-        spanNode.className = 'red-font';
-        spanNode.appendChild(document.createTextNode(format.number(fail)));
+        spanNode.appendChild(
+            document.createTextNode(format.number(pass)));
 
         smallNode.insertAdjacentHTML('beforeend', '&nbsp;/&nbsp;');
 
         spanNode = smallNode.appendChild(document.createElement('span'));
         spanNode.className = 'yellow-font';
         spanNode.appendChild(
-            document.createTextNode(format.number(unknown)));
+            document.createTextNode(format.number(fail)));
+
+        smallNode.insertAdjacentHTML('beforeend', '&nbsp;/&nbsp;');
+
+        spanNode = smallNode.appendChild(document.createElement('span'));
+        spanNode.className = 'red-font';
+        spanNode.appendChild(document.createTextNode(
+            format.number(regression)));
 
         smallNode.appendChild(document.createTextNode(')'));
 
@@ -238,9 +238,8 @@ require([
 
             html.replaceContent(
                 document.getElementById('test-count-' + lab),
-                /* ToDo: pass/warning/fail */
-                createLabResultsCount(res['total'], res['success'],
-                                      res['regressions'], res['unknown'])
+                createLabResultsCount(res['success'], res['failure'],
+                                      res['regression'])
             );
         });
     }
@@ -258,7 +257,7 @@ require([
             planMap.set(planId, planData);
         });
 
-        function parseBatchData(planData, planId, map) {
+        function parseBatchData(planData, planId) {
             var panelId = planId + '-panel';
             var statusId = planId + '-status';
             var status;
@@ -481,14 +480,6 @@ require([
 
             batchOps.push({
                 method: 'GET',
-                operation_id: [lab, 'total'],
-                resource: 'count',
-                document: 'test_case',
-                query: qStr,
-            });
-
-            batchOps.push({
-                method: 'GET',
                 operation_id: [lab, 'success'],
                 resource: 'count',
                 document: 'test_case',
@@ -497,18 +488,18 @@ require([
 
             batchOps.push({
                 method: 'GET',
-                operation_id: [lab, 'regressions'],
+                operation_id: [lab, 'failure'],
                 resource: 'count',
-                document: 'test_regression',
-                query: qStr,
+                document: 'test_case',
+                query: qStr + '&status=FAIL&&regression_id=null',
             });
 
             batchOps.push({
                 method: 'GET',
-                operation_id: [lab, 'unknown'],
+                operation_id: [lab, 'regression'],
                 resource: 'count',
-                document: 'test_case',
-                query: qStr + '&status=FAIL&status=SKIP&regression_id=null',
+                document: 'test_regression',
+                query: qStr,
             });
         }
 

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.9.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel-plan.2020.9.js
@@ -237,6 +237,7 @@ require([
 
             html.replaceContent(
                 document.getElementById('test-count-' + lab),
+                /* ToDo: pass/warning/fail */
                 createLabResultsCount(res['total'], res['success'],
                                       res['regressions'], res['unknown'])
             );

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.9.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.9.js
@@ -251,15 +251,6 @@ require([
                 'plan': plan,
             });
 
-            /* Total number of test cases */
-            batchOps.push({
-                method: 'GET',
-                operation_id: 'test-total-count-' + plan,
-                resource: 'count',
-                document: 'test_case',
-                query: qStr,
-            });
-
             /* Number of passing test cases */
             batchOps.push({
                 method: 'GET',
@@ -269,6 +260,15 @@ require([
                 query: qStr + '&status=PASS',
             });
 
+            /* Number of warning test results */
+            batchOps.push({
+                method: 'GET',
+                operation_id: 'test-warning-count-' + plan,
+                resource: 'count',
+                document: 'test_case',
+                query: qStr + '&status=FAIL&regression_id=null',
+            });
+
             /* Number of test case regressions */
             batchOps.push({
                 method: 'GET',
@@ -276,15 +276,6 @@ require([
                 resource: 'count',
                 document: 'test_regression',
                 query: qStr,
-            });
-
-            /* Number of unknown test results */
-            batchOps.push({
-                method: 'GET',
-                operation_id: 'test-warning-count-' + plan,
-                resource: 'count',
-                document: 'test_case',
-                query: qStr + '&status=FAIL&status=SKIP&regression_id=null',
             });
         }
 

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.9.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.9.js
@@ -130,10 +130,11 @@ require([
             var results = response.result;
             var total = results[0].result[0].count;
             var pass = results[1].result[0].count;
-            var regressions = results[2].result[0].count;
-            var unknown = results[3].result[0].count;
+            var fail = results[2].result[0].count;
+            var regressions = results[3].result[0].count;
+            var unknown = results[4].result[0].count;
 
-            return [total, [pass, regressions, unknown]];
+            return [total, [pass, fail, regressions, unknown]];
         }
 
         chart.testpie({
@@ -164,7 +165,7 @@ require([
 
             tooltipNode = html.tooltip();
             tooltipNode.setAttribute(
-                'title', 'Total/Successful/Regressions/Other test results');
+                'title', 'Successful/Regressions/Failures');
             tooltipNode.appendChild(
                 document.createTextNode('Test Results'));
 
@@ -290,9 +291,29 @@ require([
     }
 
     function getBatchStatusDone(response) {
+        var planMap = new Map();
+
         response.result.forEach(function(data) {
-            var node = document.getElementById(data.operation_id);
-            var status = (data.result[0].count == 0 ? "PASS" : "FAIL");
+            var planId = data.operation_id[0];
+            var key = data.operation_id[1];
+            var planData;
+
+            planData = planMap.get(planId) || {};
+            planData[key] = data.result[0].count;
+            planMap.set(planId, planData);
+        });
+
+        planMap.forEach(function(planData, planId) {
+            var node = document.getElementById(planId);
+            var status;
+
+            if (planData.regressions)
+                status = "FAIL";
+            else if (planData.warnings)
+                status = "WARNING";
+            else
+                status = "PASS";
+
             node.appendChild(ttest.statusNode(status));
         });
     }
@@ -310,6 +331,7 @@ require([
             var kernel = result.kernel;
             var branch = result.git_branch;
             var plan = result.name;
+            var idStr = 'status-' + plan;
             var qStr;
 
             qStr = URI.buildQuery({
@@ -322,10 +344,19 @@ require([
             /* Number of test case regressions */
             batchOps.push({
                 method: 'GET',
-                operation_id: 'status-' + plan,
+                operation_id: [idStr, 'regressions'],
                 resource: 'count',
                 document: 'test_regression',
                 query: qStr,
+            });
+
+            /* Number of failed test cases that aren't regressions */
+            batchOps.push({
+                method: 'GET',
+                operation_id: [idStr, 'warnings'],
+                resource: 'count',
+                document: 'test_case',
+                query: qStr + '&status=FAIL&regression_id=null',
             });
         }
 
@@ -415,6 +446,15 @@ require([
             query: qStr + '&status=PASS',
         });
 
+        /* Number of failures results */
+        batchOps.push({
+            method: 'GET',
+            operation_id: 'test-warning-count',
+            resource: 'count',
+            document: 'test_case',
+            query: qStr + '&status=FAIL&regression_id=null',
+        });
+
         /* Number of test case regressions */
         batchOps.push({
             method: 'GET',
@@ -427,10 +467,10 @@ require([
         /* Number of unknown test results */
         batchOps.push({
             method: 'GET',
-            operation_id: 'test-warning-count',
+            operation_id: 'test-unknowwwn-count',
             resource: 'count',
             document: 'test_case',
-            query: qStr + '&status=FAIL&status=SKIP&regression_id=null',
+            query: qStr + '&status=SKIP',
         });
 
         deferred = request.post(

--- a/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.9.js
+++ b/app/dashboard/static/js/app/view-tests-job-branch-kernel.2020.9.js
@@ -263,7 +263,7 @@ require([
             /* Number of passing test cases */
             batchOps.push({
                 method: 'GET',
-                operation_id: 'test-success-count-' + plan,
+                operation_id: 'test-pass-count-' + plan,
                 resource: 'count',
                 document: 'test_case',
                 query: qStr + '&status=PASS',
@@ -281,7 +281,7 @@ require([
             /* Number of unknown test results */
             batchOps.push({
                 method: 'GET',
-                operation_id: 'test-unknown-count-' + plan,
+                operation_id: 'test-warning-count-' + plan,
                 resource: 'count',
                 document: 'test_case',
                 query: qStr + '&status=FAIL&status=SKIP&regression_id=null',
@@ -418,7 +418,7 @@ require([
         /* Number of passing test cases */
         batchOps.push({
             method: 'GET',
-            operation_id: 'test-success-count',
+            operation_id: 'test-pass-count',
             resource: 'count',
             document: 'test_case',
             query: qStr + '&status=PASS',
@@ -436,7 +436,7 @@ require([
         /* Number of unknown test results */
         batchOps.push({
             method: 'GET',
-            operation_id: 'test-unknown-count',
+            operation_id: 'test-warning-count',
             resource: 'count',
             document: 'test_case',
             query: qStr + '&status=FAIL&status=SKIP&regression_id=null',

--- a/app/dashboard/static/js/worker/count-status.js
+++ b/app/dashboard/static/js/worker/count-status.js
@@ -1,9 +1,9 @@
 /* globals onmessage: true, postMessage: true */
 /*!
  * kernelci dashboard.
- * 
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
@@ -30,38 +30,47 @@ onmessage = function(message) {
     'use strict';
     var counted,
         failed,
-        other,
+        unknown,
         passed,
-        results,
-        total;
+        warning,
+        results;
 
     function _count(result) {
-        switch (result.status) {
+        var status;
+
+        if ((result.status == "PASS") && result.warnings)
+            status = 'WARNING';
+        else
+            status = result.status;
+
+        switch (status) {
             case 'FAIL':
-                failed = failed + 1;
+                failed += 1;
                 break;
             case 'PASS':
-                passed = passed + 1;
+                passed += 1;
+                break;
+            case 'WARNING':
+                warning += 1;
                 break;
             default:
-                other = other + 1;
+                unknown += 1;
                 break;
         }
-        total = total + 1;
     }
 
     counted = null;
 
     if (message.data) {
         failed = 0;
-        other = 0;
+        warning = 0;
         passed = 0;
-        total = 0;
+        unknown = 0;
         results = message.data.result;
 
         if (results.length > 0) {
             results.forEach(_count);
-            counted = [total, [passed, failed, other]];
+            counted = [results.length, [passed, warning, failed, unknown]];
         }
     }
 

--- a/app/dashboard/templates/builds-job-branch-kernel.html
+++ b/app/dashboard/templates/builds-job-branch-kernel.html
@@ -83,6 +83,8 @@
                         <tr>
                             <td id="success-cell" class="click-btn">0</td>
                             <td>&nbsp;/&nbsp;</td>
+                            <td id="warning-cell" class="click-btn">0</td>
+                            <td>&nbsp;/&nbsp;</td>
                             <td id="fail-cell" class="click-btn">0</td>
                             <td>&nbsp;/&nbsp;</td>
                             <td id="unknown-cell" class="click-btn">0</td>
@@ -103,7 +105,8 @@
             <div class="btn-group btn-group-sm">
                 <button id="all-btn" type="button" class="btn btn-default click-btn" disabled>All</button>
                 <button id="success-btn" type="button" class="btn btn-default click-btn" disabled>Successful</button>
-                <button id="fail-btn" type="button" class="btn btn-default click-btn" disabled>Failed</button>
+                <button id="fail-btn" type="button" class="btn btn-default click-btn" disabled>Errors</button>
+                <button id="warning-btn" type="button" class="btn btn-default click-btn" disabled>Warnings</button>
                 <button id="unknown-btn" type="button" class="btn btn-default click-btn" disabled>Unknown</button>
             </div>
         </div>

--- a/app/dashboard/templates/test-buttons-row.html
+++ b/app/dashboard/templates/test-buttons-row.html
@@ -3,6 +3,7 @@
         <button id="all-btn" type="button" class="btn btn-default" disabled>All</button>
         <button id="success-btn" type="button" class="btn btn-default" disabled>Successful</button>
         <button id="fail-btn" type="button" class="btn btn-default" disabled>Regressions</button>
+        <button id="warning-btn" type="button" class="btn btn-default" disabled>Failures</button>
         <button id="unknown-btn" type="button" class="btn btn-default" disabled>Unknown</button>
     </div>
 </div>

--- a/app/dashboard/templates/tests-plan-id.html
+++ b/app/dashboard/templates/tests-plan-id.html
@@ -98,6 +98,8 @@
                       <tr>
                           <td id="show-pass" class="click-btn">0</td>
                           <td>&nbsp;/&nbsp;</td>
+                          <td id="show-warning" class="click-btn">0</td>
+                          <td>&nbsp;/&nbsp;</td>
                           <td id="show-fail" class="click-btn">0</td>
                           <td>&nbsp;/&nbsp;</td>
                           <td id="show-unknown" class="click-btn">0</td>
@@ -120,6 +122,7 @@
                     <button id="btn-total" type="button" class="btn btn-default" disabled>All</button>
                     <button id="btn-pass" type="button" class="btn btn-default" disabled>Successful</button>
                     <button id="btn-regressions" type="button" class="btn btn-default" disabled>Regressions</button>
+                    <button id="btn-failures" type="button" class="btn btn-default" disabled>Failures</button>
                     <button id="btn-unknown" type="button" class="btn btn-default" disabled>Unknown</button>
                 </div>
             </div>


### PR DESCRIPTION
Fix the status of test cases that have always failed, to show them as failures rather than "unknown".  Also update a bunch of related things as a side effect, including:

- [x] show number of builds with warnings rather than "unknown" in badge counters
- [x] show number of test failures that aren't regressions rather than "unknown" in badge counters
- [x] drop total number of builds and tests to simplify UI with 3 badges rather than add one for "unknown" and have 5 badges
- [x] show failures for test cases that have always failed in orange, and unknown (skipped...) in grey
- [x] update pie charts with total number and builds with warnings / failed tests that aren't regressions + actual unknowns
- [x] update test plan status to show "fail" in orange when there are failures but no regressions