### PR TITLE
Encode branch names in links on SoC views

### DIFF
--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.6.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel-plan.2020.6.js
@@ -80,7 +80,8 @@ require([
         branchNode = html.tooltip();
         branchNode.title = "All results for branch &#171;" + branch + "&#187;";
         branchLink = document.createElement('a');
-        branchLink.href = "/job/" + job + "/branch/" + branch;
+        branchLink.href =
+            "/job/" + job + "/branch/" + URI.encode(branch) + "/";
         branchLink.appendChild(html.tree());
         branchNode.appendChild(document.createTextNode(branch));
         branchNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
@@ -94,7 +95,9 @@ require([
             "Build reports for &#171;" + job + "&#187; - " + kernel;
         buildsLink = document.createElement('a');
         buildsLink.href =
-            "/build/" + job + "/branch/" + branch + "/kernel/" + kernel;
+            "/build/" + job +
+            "/branch/" + URI.encode(branch) +
+            "/kernel/" + kernel + "/";
         buildsLink.appendChild(html.build());
         describeNode.appendChild(document.createTextNode(kernel));
         describeNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');

--- a/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.6.js
+++ b/app/dashboard/static/js/app/view-socs-soc-job-kernel.2020.6.js
@@ -111,7 +111,7 @@ define([
         tooltipNode.title =
             "All results for branch &#171;" + gitBranch + "&#187;";
         aNode = document.createElement('a');
-        aNode.href = "/job/" + gJob + "/branch/" + gitBranch;
+        aNode.href = "/job/" + gJob + "/branch/" + URI.encode(gitBranch) + "/";
         aNode.appendChild(html.tree());
         tooltipNode.appendChild(document.createTextNode(gitBranch));
         tooltipNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');
@@ -130,7 +130,9 @@ define([
             "Build reports for &#171;" + gJob + "&#187; - " + gKernel;
         aNode = document.createElement('a');
         aNode.href =
-            "/build/" + gJob + "/branch/" + gitBranch + "/kernel/" + gKernel;
+            "/build/" + gJob +
+            "/branch/" + URI.encode(gitBranch) +
+            "/kernel/" + gKernel;
         aNode.appendChild(html.build());
         tooltipNode.appendChild(aNode);
 
@@ -142,14 +144,11 @@ define([
             "Test reports for &#171;" + gJob + "&#187; - " + gKernel;
 
         aNode = tooltipNode.appendChild(document.createElement('a'));
-        var str = '/test/job/';
-        str += gJob;
-        str += '/branch/';
-        str += gitBranch;
-        str += '/kernel/';
-        str += gKernel;
-        str += '/';
-        aNode.setAttribute('href', str);
+        var href =
+            '/test/job/' + gJob +
+            '/branch/' + URI.encode(gitBranch) +
+            '/kernel/' + gKernel + '/';
+        aNode.setAttribute('href', href);
         aNode.appendChild(html.test());
 
         tooltipNode.appendChild(aNode);


### PR DESCRIPTION
Also encode branch names in URLs used on SoC views to handle slashes
in branch names in particular.  These are URLs pointing at the jobs
and tests pages, since the SoC views don't show branch-specific
results.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>