### PR TITLE
Fix renderTree() in tables/common.js

### DIFF
--- a/app/dashboard/static/js/app/tables/common.js
+++ b/app/dashboard/static/js/app/tables/common.js
@@ -244,7 +244,7 @@ define([
                 aNode.appendChild(document.createTextNode(tree));
                 tooltipNode.appendChild(aNode);
             } else {
-                tooltipNode.appendChild(document.createTextNode(data));
+                tooltipNode.appendChild(document.createTextNode(tree));
             }
             rendered = tooltipNode.outerHTML;
         }


### PR DESCRIPTION
Fix undefine variable in the renderTree() function in
tables/common.js.  It's not clear whether this code path is actually
used anywhere, the error was found using eslint.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>