### PR TITLE
Fix links to build details on tests-plan-id view

### DIFF
--- a/app/dashboard/static/js/app/view-tests-plan-id.2020.9.js
+++ b/app/dashboard/static/js/app/view-tests-plan-id.2020.9.js
@@ -136,7 +136,7 @@ require([
         defconfigLink.appendChild(html.external());
         defconfigNode.appendChild(defconfigLink);
         buildLink = document.createElement('a');
-        buildLink.href = "/build/id/" + results._id.$oid;
+        buildLink.href = "/build/id/" + results.build_id.$oid;
         buildLink.appendChild(html.build());
         buildLink.title = "Build details";
         defconfigNode.insertAdjacentHTML('beforeend', '&nbsp;&mdash;&nbsp;');


### PR DESCRIPTION
Fix the link from the test plan results view to the individual build,
using the correct build id from the test document.

Fixes: 99675076221f ("Fix defconfig link on view-tests-plan-id")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>