### PR TITLE
routes.py: clean-up missing boot view

### DIFF
--- a/app/dashboard/utils/route.py
+++ b/app/dashboard/utils/route.py
@@ -27,7 +27,6 @@
 
 from flask import current_app as app
 
-import dashboard.views.boot as vboot
 import dashboard.views.build as vbuild
 import dashboard.views.generic as vgeneric
 import dashboard.views.index as vindex
@@ -170,13 +169,6 @@ def init():
         "/job/<string:job>/branch/<path:branch>/feed.xml",
         "job-branch-feed",
         jobfeed.job_branch_feed,
-        methods=["GET"]
-    )
-
-    # Boots related URLs.
-    add_rule(
-        "/boot/",
-        view_func=vboot.BootAllView.as_view("boots"),
         methods=["GET"]
     )
 


### PR DESCRIPTION
Delete vboot route because boot views have gone and during deploy it was breaking front-end app to start-up.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>