### PR TITLE
Replace the "Build log" text with plural logs

### DIFF
--- a/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.10.js
+++ b/app/dashboard/static/js/app/view-builds-job-branch-kernel.2020.10.js
@@ -560,7 +560,7 @@ require([
 
             if (result.build_log !== null) {
                 dtNode = dlNode.appendChild(document.createElement('dt'));
-                dtNode.appendChild(document.createTextNode('Build log'));
+                dtNode.appendChild(document.createTextNode('Build logs'));
 
                 ddNode = dlNode.appendChild(document.createElement('dd'));
                 aNode = ddNode.appendChild(document.createElement('a'));

--- a/app/dashboard/templates/builds-id.html
+++ b/app/dashboard/templates/builds-id.html
@@ -122,7 +122,7 @@
     </div>
     <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
         <dl class="dl-horizontal">
-            <dt>Build log</dt>
+            <dt>Build logs</dt>
             <dd class="loading-content" id="build-log">
                 <small>
                     <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;


### PR DESCRIPTION
There are now several log files, so use the plural form on the frontend views.