### PR TITLE
dashboard/templates: Remove graphs from jobs-job{-branch} templates

### DIFF
--- a/app/dashboard/static/js/app/view-jobs-job-branch.2020.10.js
+++ b/app/dashboard/static/js/app/view-jobs-job-branch.2020.10.js
@@ -25,7 +25,6 @@ require([
     'utils/error',
     'utils/table',
     'utils/urls',
-    'charts/passrate',
     'utils/html',
     'tables/job',
     'URI',
@@ -43,101 +42,6 @@ require([
     }, 15);
 
     gNumberRange = 20;
-
-    function getTestStatsFail() {
-        html.replaceContent(
-            document.getElementById('test-pass-rate'),
-            html.errorDiv('Error loading test data.'));
-    }
-
-    function getTestStatsDone(response) {
-        chart.testpassrate('test-pass-rate', response);
-    }
-
-    function getTestStats(startDate, dateRange) {
-        var data;
-        var deferred;
-
-        data = {
-            job: gJobName,
-            git_branch: gBranchName,
-            sort: 'created_on',
-            sort_order: 1,
-            created_on: startDate,
-            date_range: dateRange,
-            field: ['status', 'kernel', 'created_on', 'job']
-        };
-
-        deferred = r.get('/_ajax/test/case', data);
-        $.when(deferred)
-            .fail(e.error, getTestStatsFail)
-            .done(getTestStatsDone);
-    }
-
-    function getBuildsStatsFail() {
-        html.replaceContent(
-            document.getElementById('build-pass-rate'),
-            html.errorDiv('Error loading build data.'));
-    }
-
-    function getBuildsStatsDone(response) {
-        chart.buildpassrate('build-pass-rate', response);
-    }
-
-    function getBuildsStats(startDate, dateRange) {
-        var data;
-        var deferred;
-
-        data = {
-            job: gJobName,
-            git_branch: gBranchName,
-            sort: 'created_on',
-            sort_order: 1,
-            created_on: startDate,
-            date_range: dateRange,
-            field: ['status', 'kernel', 'created_on', 'job']
-        };
-
-        deferred = r.get('/_ajax/build', data);
-        $.when(deferred)
-            .fail(e.error, getBuildsStatsFail)
-            .done(getBuildsStatsDone);
-    }
-
-    function getTrendsData(response) {
-        var firstDate;
-        var lDateRange;
-        var lastDate;
-        var resLen;
-        var results;
-
-        results = response.result;
-        resLen = results.length;
-        lDateRange = 0;
-
-        if (resLen > 0) {
-            firstDate = new Date(results[0].created_on.$date);
-            if (resLen > 1) {
-                lastDate = new Date(results[resLen - 1].created_on.$date);
-                lDateRange = Math.round((firstDate - lastDate) / 86400000);
-            }
-
-            setTimeout(function() {
-                getBuildsStats(firstDate.toCustomISODate(), lDateRange);
-            }, 25);
-            setTimeout(function() {
-                getTestStats(firstDate.toCustomISODate(), lDateRange);
-            }, 25);
-        } else {
-            html.replaceContent(
-                document.getElementById('build-pass-rate'),
-                html.errorDiv('No build data available.'));
-
-            html.replaceContent(
-                document.getElementById('test-pass-rate'),
-                html.errorDiv('No test data available.'));
-        }
-    }
 
     function getBuildTestsCountFail() {
         html.replaceByClass('count-badge', '&infin;');
@@ -460,8 +364,8 @@ require([
         $.when(deferred)
             .fail(
                 e.error,
-                getBuildsFailed, getBuildsStatsFail, getTestStatsFail)
-            .done(getTrendsData, getBuildsDone, getBuildTestsCount);
+                getBuildsFailed)
+            .done(getBuildsDone, getBuildTestsCount);
     }
 
     function getDetailsDone(response) {

--- a/app/dashboard/static/js/app/view-jobs-job.2020.10.js
+++ b/app/dashboard/static/js/app/view-jobs-job.2020.10.js
@@ -25,7 +25,6 @@ require([
     'utils/error',
     'utils/table',
     'utils/urls',
-    'charts/passrate',
     'utils/html',
     'tables/job',
     'URI',
@@ -46,93 +45,6 @@ require([
     gSearchFilter = null;
 
     gNumberRange = 20;
-
-    function getTestStatsFail() {
-        html.replaceContent(
-            document.getElementById('test-pass-rate'),
-            html.errorDiv('Error loading test data.'));
-    }
-
-    function getTestStatsDone(response) {
-        chart.testpassrate('test-pass-rate', response);
-    }
-
-    function getTestStats(startDate, dateRange) {
-        var data;
-
-        data = {
-            job: gJobName,
-            sort: 'created_on',
-            sort_order: 1,
-            created_on: startDate,
-            date_range: dateRange,
-            field: ['status', 'kernel', 'created_on', 'job'],
-            nfield: ['_id']
-        };
-
-        $.when(r.get('/_ajax/test/case', data))
-            .fail(e.error, getTestStatsFail)
-            .done(getTestStatsDone);
-    }
-
-    function getBuildsStatsFail() {
-        html.replaceContent(
-            document.getElementById('build-pass-rate'),
-            html.errorDiv('Error loading build data.'));
-    }
-
-    function getBuildsStatsDone(response) {
-        chart.buildpassrate('build-pass-rate', response);
-    }
-
-    function getBuildsStats(startDate, dateRange) {
-        var data;
-
-        data = {
-            job: gJobName,
-            sort: 'created_on',
-            sort_order: 1,
-            created_on: startDate,
-            date_range: dateRange,
-            field: ['status', 'kernel', 'created_on', 'job'],
-            nfield: ['_id']
-        };
-
-        $.when(r.get('/_ajax/build', data))
-            .fail(e.error, getBuildsStatsFail)
-            .done(getBuildsStatsDone);
-    }
-
-    function getTrendsData(response) {
-        var firstDate;
-        var lDateRange;
-        var lastDate;
-        var resLen;
-        var results;
-
-        results = response.result;
-        resLen = results.length;
-        lDateRange = 0;
-
-        if (resLen > 0) {
-            firstDate = new Date(results[0].created_on.$date);
-            if (resLen > 1) {
-                lastDate = new Date(results[resLen - 1].created_on.$date);
-                lDateRange = Math.round((firstDate - lastDate) / 86400000);
-            }
-
-            getBuildsStats(firstDate.toCustomISODate(), lDateRange);
-            getTestStats(firstDate.toCustomISODate(), lDateRange);
-        } else {
-            html.replaceContent(
-                document.getElementById('build-pass-rate'),
-                html.errorDiv('No build data available.'));
-
-            html.replaceContent(
-                document.getElementById('test-pass-rate'),
-                html.errorDiv('No test data available.'));
-        }
-    }
 
     function getBuildTestCountFail() {
         html.replaceByClass('count-badge', '&infin;');
@@ -496,8 +408,8 @@ require([
         $.when(r.get('/_ajax/build', data))
             .fail(
                 e.error,
-                getBuildsFailed, getBuildsStatsFail, getTestStatsFail)
-            .done(getTrendsData, getBuildsDone, getBuildTestCount);
+                getBuildsFailed)
+            .done(getBuildsDone, getBuildTestCount);
     }
 
     function getDetailsDone(response) {

--- a/app/dashboard/templates/jobs-job-branch.html
+++ b/app/dashboard/templates/jobs-job-branch.html
@@ -62,39 +62,6 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-        <div class="page-header">
-            <h3>Trends</h3>
-        </div>
-        <div>
-            <h4>Build Pass Rate</h4>
-            <div id="build-pass-rate">
-                <div class="pull-center">
-                    <span id="build-count">
-                        <small>
-                            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-                            &nbsp;calculating build pass rate&hellip;
-                        </small>
-                    </span>
-                </div>
-            </div>
-        </div>
-        <div>
-            <h4>Test Pass Rate</h4>
-            <div id="test-pass-rate">
-                <div class="pull-center">
-                    <span id="test-count">
-                        <small>
-                            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-                            &nbsp;calculating test pass rate&hellip;
-                        </small>
-                    </span>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 <input type="hidden" id="job-name" value="{{ job_name }}">
 <input type="hidden" id="search-filter" value="{{ search_filter }}">
 <input type="hidden" id="page-len" value="{{ page_len }}">

--- a/app/dashboard/templates/jobs-job.html
+++ b/app/dashboard/templates/jobs-job.html
@@ -62,39 +62,6 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-        <div class="page-header">
-            <h3>Trends</h3>
-        </div>
-        <div>
-            <h4>Build Pass Rate</h4>
-            <div id="build-pass-rate">
-                <div class="pull-center">
-                    <span id="build-count">
-                        <small>
-                            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-                            &nbsp;calculating build pass rate&hellip;
-                        </small>
-                    </span>
-                </div>
-            </div>
-        </div>
-        <div>
-            <h4>Test Pass Rate</h4>
-            <div id="test-pass-rate">
-                <div class="pull-center">
-                    <span id="test-count">
-                        <small>
-                            <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-                            &nbsp;calculating test pass rate&hellip;
-                        </small>
-                    </span>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 <input type="hidden" id="job-name" value="{{ job }}">
 <input type="hidden" id="search-filter" value="{{ search_filter }}">
 <input type="hidden" id="page-len" value="{{ page_len }}">


### PR DESCRIPTION
In the job/<tree>/ and job/<tree>/<branch> views we often get a "Error
loading test data" error for the test pass rate graph at the bottom of the
page.

When viewing an entire tree at this level the build/test pass rate graphs
don't provide any useful information anyway, so let's just remove them.

If anyone manages to work out what is causing the issues in future we can
always restore one or both of the graphs again.

Signed-off-by: Chris Paterson <chris.paterson2@renesas.com>