### PR TITLE
Connect new API to the old dashboard

### DIFF
--- a/app/dashboard/__init__.py
+++ b/app/dashboard/__init__.py
@@ -196,6 +196,9 @@ def static_html_proxy(path):
 @app.route(
     "/_ajax/test/regression",
     defaults={"api": "TEST_REGRESSION_API_ENDPOINT"}, methods=["GET"])
+@app.route(
+    "/_ajax/nodes",
+    defaults={"api": "NEW_API_ENDPOINT"}, methods=["GET"])
 def ajax_get(api):
     if validate_csrf(request.headers.get(CSRF_TOKEN_H, None)):
         return backend.ajax_get(request, app_conf_get(api), timeout=60 * 20)

--- a/app/dashboard/default_settings.py
+++ b/app/dashboard/default_settings.py
@@ -64,6 +64,7 @@ JOB_ID_LOGS_ENPOINT = "/job/%s/logs"
 TEST_GROUP_API_ENDPOINT = "/test/group"
 TEST_CASE_API_ENDPOINT = "/test/case"
 TEST_REGRESSION_API_ENDPOINT = "/test/regression"
+NEW_API_ENDPOINT = "/nodes"
 
 # Default date range to show the results. The higher the value, the more
 # data will need to be loaded from the server and parsed. It can take time

--- a/app/dashboard/static/js/app/tables/common.js
+++ b/app/dashboard/static/js/app/tables/common.js
@@ -125,6 +125,10 @@ define([
                 tooltipNode.setAttribute('title', defaults.warning);
                 tooltipNode.appendChild(html.warning());
                 break;
+            case 'DONE':
+                tooltipNode.setAttribute('title', defaults.done);
+                tooltipNode.appendChild(html.success());
+                break;
             default:
                 tooltipNode.setAttribute('title', defaults.default);
                 tooltipNode.appendChild(html.unknown());
@@ -255,7 +259,11 @@ define([
                 node = _dateNode(date).firstElementChild;
                 rendered = node.outerHTML;
             } else {
-                created = new Date(date.$date);
+                if (date.$date) {
+                    created = new Date(date.$date);
+                } else {
+                    created = new Date(date);
+                }
                 rendered = created.toCustomISODate();
             }
         } else {

--- a/app/dashboard/static/js/app/tables/job.js
+++ b/app/dashboard/static/js/app/tables/job.js
@@ -31,6 +31,7 @@ define([
         pass: 'Build completed',
         build: 'Building',
         fail: 'Build failed',
+        done: 'Job done',
         default: 'Unknown status'
     };
 

--- a/app/dashboard/static/js/app/utils/html.js
+++ b/app/dashboard/static/js/app/utils/html.js
@@ -1,6 +1,8 @@
 /*!
  * kernelci dashboard.
  *
+ * Copyright (C) 2022 Collabora Ltd.
+ *
  * Copyright (C) 2014, 2015, 2016, 2017  Linaro Ltd.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -513,7 +515,11 @@ define([
 
         frag = document.createDocumentFragment();
 
-        created = new Date(date.$date);
+        if (date.$date) {
+            created = new Date(date.$date);
+        } else {
+            created = new Date(date);
+        }
         timeNode = frag.appendChild(document.createElement('time'));
         timeNode.setAttribute('datetime', created.toISOString());
         timeNode.appendChild(

--- a/app/dashboard/static/js/app/view-new-api-job-branch-kernel-plan.2022.11.js
+++ b/app/dashboard/static/js/app/view-new-api-job-branch-kernel-plan.2022.11.js
@@ -1,0 +1,375 @@
+/*!
+ * kernelci dashboard.
+ *
+ * Copyright (C) 2020 Collabora Limited
+ * Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+require([
+    'jquery',
+    'charts/passpie',
+    'tables/test',
+    'utils/error',
+    'utils/init',
+    'utils/html',
+    'utils/request',
+    'utils/table',
+    'utils/urls',
+    'URI',
+], function($, pieChart, ttable, error, init, html, request, table,
+            urls, URI) {
+    'use strict';
+
+    var gPlan;
+    var gKernel;
+    var gBranch;
+    var gJob;
+    var gFileServer;
+    var gTestsTable;
+
+    setTimeout(function() {
+        document.getElementById('li-test').setAttribute('class', 'active');
+    }, 15);
+
+    function detailsFailed() {
+        html.replaceByClassTxt('loading-content', '?');
+    }
+
+    function updateDetails(results) {
+        var job;
+        var branch;
+        var kernel;
+        var commit;
+        var treeNode;
+        var describeNode;
+        var branchNode;
+        var planNode;
+        var gitNode;
+        var createdOn;
+        var dateNode;
+        var url;
+        var plan;
+
+        job = results.revision.tree;
+        branch = results.revision.branch;
+        kernel = results.revision.describe;
+        commit = results.revision.commit;
+        url = results.revision.url.replace('.git', '/commit/'+commit);
+        plan = results.group;
+
+        treeNode = html.tooltip();
+        treeNode.title = "All results for tree &#171;" + job + "&#187;";
+        treeNode.appendChild(document.createTextNode(job));
+
+        planNode = html.tooltip();
+        planNode.title = "All results for test plan &#171;" + plan + "&#187;";
+        planNode.appendChild(document.createTextNode(plan));
+
+        branchNode = html.tooltip();
+        branchNode.title = "All results for branch &#171;" + branch + "&#187;";
+        branchNode.appendChild(document.createTextNode(branch));
+
+        describeNode = html.tooltip();
+        describeNode.title = "Build results for &#171;" + kernel + "&#187; - ";
+        describeNode.appendChild(document.createTextNode(kernel));
+
+        gitNode = document.createElement('a');
+        gitNode.appendChild(document.createTextNode(url));
+        gitNode.href = url;
+        gitNode.title = "Git URL";
+
+        createdOn = new Date(results.created);
+        dateNode = document.createElement('time');
+        dateNode.setAttribute('datetime', createdOn.toISOString());
+        dateNode.appendChild(
+            document.createTextNode(createdOn.toCustomISODate()));
+
+        html.replaceContent(
+            document.getElementById('tree'), treeNode);
+        html.replaceContent(
+            document.getElementById('plan'), planNode);
+        html.replaceContent(
+            document.getElementById('git-branch'), branchNode);
+        html.replaceContent(
+            document.getElementById('git-describe'), describeNode);
+        html.replaceContent(
+            document.getElementById('git-url'), gitNode);
+        html.replaceContent(
+            document.getElementById('job-date'), dateNode);
+        html.replaceContent(
+            document.getElementById('plan-title'),
+            document.createTextNode(results.group));
+        html.replaceContent(
+            document.getElementById('kernel-title'),
+            document.createTextNode(results.revision.describe));
+        html.replaceContent(
+            document.getElementById('tree-title'),
+            document.createTextNode(job));
+        html.replaceContent(
+            document.getElementById('branch-title'),
+            document.createTextNode(branch));
+    }
+
+    function updateChart(testCount) {
+        function countTests(tc) {
+            return [
+                tc['total'],
+                [tc['pass'], tc['failures'], tc['regressions'], tc['unknown']]
+            ];
+        }
+
+        pieChart.testpie({
+            element: 'test-chart',
+            countFunc: countTests,
+            response: testCount,
+            legend: true,
+            legendIds: {
+                'pass': '#show-pass',
+                'warning': '#show-warning',
+                'fail': '#show-fail',
+                'unknown': '#show-unknown',
+            },
+            legendTitles: {
+                'pass': 'Successful',
+                'warning': 'Failures',
+                'fail': 'Regressions',
+                'unknown': 'Unknown',
+            },
+            size: {
+                height: 200,
+                width: 200,
+            },
+            radius: {inner: -30, outer: -42},
+        });
+    }
+
+    function listenForTableEvents(testCount) {
+        var btnList = ['total', 'pass', 'regressions', 'failures', 'unknown'];
+
+        function _tableFilter(event) {
+            var activeId = event.target.id;
+            var status = activeId.substring('btn-'.length);
+
+            if (status == 'total') {
+                status = '';
+            } else if (status == 'regressions') {
+                status = 'fail';
+            } else if (status == 'failures') {
+                status = 'warning';
+            }
+
+            gTestsTable.table.column(2).search(status).draw();
+
+            btnList.forEach(function(id) {
+                var btnId = 'btn-' + id;
+                var ele = document.getElementById(btnId);
+
+                if (btnId == activeId) {
+                    html.addClass(ele, 'active');
+                } else {
+                    html.removeClass(ele, 'active');
+                }
+            });
+        }
+
+        btnList.forEach(function(id) {
+            var ele = document.getElementById('btn-' + id);
+            ele.addEventListener('click', _tableFilter, true);
+            if (testCount[id])
+                ele.removeAttribute('disabled');
+            if (id == 'total')
+                html.addClass(ele, 'active');
+        });
+    }
+
+    function updateTestsTable(results) {
+        var columns;
+        var data;
+        function _renderStatus(data, type) {
+            if (type == "display") {
+                var node = document.createElement('div');
+                node.appendChild(ttable.statusNode(data));
+                return node.outerHTML;
+            } else {
+                return data;
+            }
+        }
+
+        data = [];
+        results.forEach(function(item) {
+            var status;
+
+            if (item.result == 'pass')
+                status = 'PASS';
+            else if (item.result == 'fail')
+                status = 'WARNING';
+            else if (item.result === null)
+                return
+            else
+                status = 'UNKNOWN';
+
+            data.push({
+                '_id': item._id,
+                'test_case_path': item.path.join('.'),
+                'measurements': '-',
+                'status': status,
+            });
+        });
+
+        columns = [
+            {
+                title: 'Test case path',
+                data: 'test_case_path',
+                type: 'string',
+                className: 'test-group-column',
+            },
+            {
+                title: 'Measurements',
+                data: 'measurements',
+                type: 'string',
+                className: 'test-group-column',
+                searchable: false,
+                orderable: false,
+            },
+            {
+                title: 'Status',
+                data: 'status',
+                type: 'string',
+                className: 'pull-center',
+                searchable: true,
+                orderable: false,
+                render: _renderStatus,
+            },
+        ];
+
+        gTestsTable
+            .data(data)
+            .columns(columns)
+            .order([0, 'asc'])
+            .paging(true)
+            .info(false)
+            .draw();
+    }
+
+    function getTestsFailed() {
+        html.removeElement(document.getElementById('table-loading'));
+        html.replaceContent(
+            document.getElementById('table-div'),
+            html.errorDiv('No test data available.')
+        );
+    }
+
+    function getTestsDone(response) {
+        if (response.length === 0) {
+            getTestsFailed();
+            return;
+        }
+
+        updateTestsTable(response.items);
+    }
+
+    function testCountDone(response) {
+        var testCount;
+        var total = 0;
+        var pass = 0;
+        var fail = 0;
+        var regressions = 0;
+        var unknown = 0;
+
+        response.forEach(function(item){
+            if (item.path.length > 2 & item.result !== null) {
+                switch(item.result) {
+                    case 'fail':
+                        fail += 1;
+                        break;
+                    case 'pass':
+                        pass += 1;
+                        break;
+                    case 'unknown':
+                        unknown += 1;
+                        break;
+                }
+            }
+        });
+
+        total = fail+pass+regressions+unknown;
+
+        testCount = {
+            'total': total,
+            'pass': pass,
+            'regressions': regressions,
+            'failures': fail,
+            'unknown': unknown,
+        };
+        updateChart(testCount);
+        listenForTableEvents(testCount);
+    }
+
+    function getPlanFailed() {
+        detailsFailed();
+    }
+
+    function getPlanDone(response) {
+        updateDetails(response.items[0]);
+        getTestsDone(response);
+        testCountDone(response.items);
+    }
+
+    function getPlan() {
+        var data;
+        if (!gPlan) {
+            getPlanFailed();
+            return;
+        }
+
+        data = {
+            'revision.tree': gJob,
+            'revision.branch': gBranch,
+            'revision.describe': gKernel,
+            group: gPlan,
+            limit: 100000,
+            offset: 0,
+        };
+
+        $.when(request.get('/_ajax/nodes', data))
+            .fail(error.error, getPlanFailed)
+            .done(getPlanDone);
+    }
+    if (document.getElementById('job-name') !== null) {
+        gJob = document.getElementById('job-name').value;
+    }
+    if (document.getElementById('branch-name') !== null) {
+        gBranch = URI.decode(document.getElementById('branch-name').value);
+    }
+    if (document.getElementById('kernel-name') !== null) {
+        gKernel = document.getElementById('kernel-name').value;
+    }
+    if (document.getElementById('plan-name') !== null) {
+        gPlan = document.getElementById('plan-name').value;
+    }
+
+    gTestsTable = table({
+        tableId: 'tests-table',
+        tableLoadingDivId: 'table-loading',
+        tableDivId: 'table-div',
+    });
+
+    setTimeout(getPlan, 10);
+
+    setTimeout(init.hotkeys, 50);
+    setTimeout(init.tooltip, 50);
+});

--- a/app/dashboard/static/js/app/view-new-api-job-branch-kernel.2022.11.js
+++ b/app/dashboard/static/js/app/view-new-api-job-branch-kernel.2022.11.js
@@ -1,0 +1,312 @@
+/*!
+ * kernelci dashboard.
+ *
+ * Copyright (C) 2022 Collabora Ltd
+ * Author: Alexandra Pereira <alexandra.pereira@collabora.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+require([
+    'jquery',
+    'utils/init',
+    'utils/html',
+    'utils/error',
+    'utils/request',
+    'utils/table',
+    'tables/test',
+    'charts/passpie',
+    'URI',
+], function($, init, html, error, request, table, ttest, chart, URI) {
+    'use strict';
+    var gJob;
+    var gBranch;
+    var gKernel;
+    var gPlansTable;
+
+    setTimeout(function() {
+        document.getElementById('li-test').setAttribute('class', 'active');
+    }, 15);
+
+    function detailsFailed() {
+        html.replaceByClassTxt('loading-content', '?');
+    }
+
+    function updateChart(response) {
+        function countTests(response) {
+            var count = {'pass': 0, 'fail': 0, 'warning': 0};
+            response.forEach(function(item){
+                count.pass += item.result.pass;
+                count.fail += item.result.fail;
+                count.warning += item.result.warning;
+            })
+            var total = count.pass + count.fail + count.warning;
+            return [total, [count.pass, count.fail, count.warning]];
+        }
+
+        chart.testpie({
+            element: 'test-chart',
+            countFunc: countTests,
+            response: response,
+            size: {
+                height: 140,
+                width: 140
+            },
+            radius: {inner: -12.5, outer: 0},
+        });
+    }
+
+    function updateDetails(results) {
+        var job;
+        var branch;
+        var kernel;
+        var commit;
+        var treeNode;
+        var describeNode;
+        var branchNode;
+        var gitNode;
+        var createdOn;
+        var dateNode;
+        var url;
+
+        job = results.tree;
+        branch = results.branch;
+        kernel = results.describe;
+        commit = results.commit;
+        url = results.url.replace('.git', '/commit/' + commit);
+
+        treeNode = html.tooltip();
+        treeNode.title = "All results for tree &#171;" + job + "&#187;";
+        treeNode.appendChild(document.createTextNode(job));
+
+        branchNode = html.tooltip();
+        branchNode.title = "All results for branch &#171;" + branch + "&#187;";
+        branchNode.appendChild(document.createTextNode(branch));
+
+        describeNode = html.tooltip();
+        describeNode.title = "Build results for &#171;" + kernel + "&#187; - ";
+        describeNode.appendChild(document.createTextNode(kernel));
+
+        gitNode = document.createElement('a');
+        gitNode.appendChild(document.createTextNode(url));
+        gitNode.href = url;
+        gitNode.title = "Git URL";
+
+        createdOn = new Date(results.created);
+        dateNode = document.createElement('time');
+        dateNode.setAttribute('datetime', createdOn.toISOString());
+        dateNode.appendChild(
+            document.createTextNode(createdOn.toCustomISODate()));
+
+        html.replaceContent(
+            document.getElementById('tree'), treeNode);
+        html.replaceContent(
+            document.getElementById('git-branch'), branchNode);
+        html.replaceContent(
+            document.getElementById('git-describe'), describeNode);
+        html.replaceContent(
+            document.getElementById('git-url'), gitNode);
+        html.replaceContent(
+            document.getElementById('job-date'), dateNode);
+    }
+
+    function getBuilds() {
+        var data;
+        var deferred;
+
+        data = {
+            'revision.tree': gJob,
+            'revision.branch': gBranch,
+            'revision.describe': gKernel,
+            limit: 100000,
+            offset: 0,
+        };
+
+        deferred = request.get('/_ajax/nodes', data);
+        $.when(deferred)
+            .fail(
+                error.error,
+                getBuildsFailed)
+            .done(getBuildsDone);
+    }
+
+    function getBuildsFailed() {
+        html.removeElement(document.getElementById('table-loading'));
+        html.replaceContent(
+            document.getElementById('table-div'),
+            html.errorDiv('Error loading build data.'));
+    }
+
+    function plansFailed() {
+        html.removeElement(document.getElementById('table-loading'));
+        html.replaceContent(
+            document.getElementById('table-div'),
+            html.errorDiv('No test data available.')
+        );
+    }
+
+    function getPlansFailed() {
+        detailsFailed();
+        plansFailed();
+    }
+
+    function getBuildsDone(response) {
+        if (response.items.length === 0) {
+            getPlansFailed();
+            return;
+        }
+        var columns;
+        var results;
+        var count = {};
+
+        response.items.forEach(function(item){
+            var date = new Date(item.created).toCustomISODate();
+            if (!(date in count) && item.group !== null) {
+                count[date] = {};
+                count[date][item.group] = {'pass':0, 'fail': 0, 'warning':0, 'id': item._id};
+            } else if (item.group !== null && !(item.group in count[date])) {
+                count[date][item.group] = {'pass':0, 'fail': 0, 'warning':0, 'id': item._id};
+            } else if (date in count && item.group in count[date]) {
+                if (item.result) {
+                    if (item.result in count[date][item.group]) {
+                        count[date][item.group][item.result]++;
+                    } else {
+                        count[date][item.group]['pass'] = 0;
+                        count[date][item.group]['fail'] = 0;
+                        count[date][item.group]['warning'] = 0;
+                        count[date][item.group]['group'] = item.group;
+                    }
+                }
+            }
+        });
+        results = Object.values(response.items).filter(item => item.path.length === 2 && item.group !== null).map((item) => {
+            var revision = item.revision;
+            var newDate = new Date(item.created);
+            revision.status = String(item.state).toUpperCase();
+            revision.created = new Date(newDate);
+            revision.group = item.group;
+            if (newDate.toCustomISODate() in count){
+                if (Object.keys(count[newDate.toCustomISODate()][item.group]).length === 0){
+                    revision.result = {'pass':0, 'fail': 0, 'warning':0};
+                } else {
+                    revision.result = count[newDate.toCustomISODate()][item.group];
+                }
+            }
+            return revision
+        });
+
+        /**
+         * Create the table column title for the tests count.
+        **/
+         function _testColumnTitle() {
+            var tooltipNode;
+
+            tooltipNode = html.tooltip();
+            tooltipNode.setAttribute(
+                'title', 'Successful/Regressions/Failures');
+            tooltipNode.appendChild(
+                document.createTextNode('Test Results'));
+
+            return tooltipNode.outerHTML;
+        }
+
+        /**
+         * Wrapper to provide the href.
+        **/
+        function _renderTestCount(data, type) {
+            return ttest.renderTestCount({data: data.id, type: type});
+        }
+
+        if (results.length === 0) {
+            html.replaceContent(
+                document.getElementById('table-div'),
+                html.errorDiv('No builds data available.'));
+        } else {
+            updateDetails(results[0]);
+            updateChart(results);
+            columns = [
+                {
+                    data: 'group',
+                    title: 'Test Plan',
+                    type: 'string',
+                    className: 'test-group-column',
+                },
+                {
+                    data: 'created',
+                    title: 'Date',
+                    type: 'date',
+                    className: 'pull-center',
+                    render: ttest.renderDate
+                },
+                {
+                    data: 'result',
+                    title: _testColumnTitle(),
+                    type: 'string',
+                    orderable: false,
+                    searchable: false,
+                    className: 'test-count pull-center',
+                    render: _renderTestCount
+                },
+                {
+                    data: 'tree',
+                    title: '',
+                    type: 'string',
+                    searchable: false,
+                    orderable: false,
+                    className: 'select-column pull-center',
+                }
+            ];
+            gPlansTable
+                .data(results)
+                .columns(columns)
+                .order([1, 'desc'])
+                .paging(true)
+                .info(false)
+                .draw();
+        }
+        results.forEach(function(data) {
+            var objectId;
+            for (var key in data.result) {
+                if (key === 'id')
+                    continue;
+                objectId = 'test-' + key + '-count-' + data.result.id;
+                html.replaceContent(
+                    document.getElementById(objectId),
+                    document.createTextNode(data.result[key]))
+            }
+        });
+    }
+
+    if (document.getElementById('job-name') !== null) {
+        gJob = document.getElementById('job-name').value;
+    }
+    if (document.getElementById('branch-name') !== null) {
+        gBranch = URI.decode(document.getElementById('branch-name').value);
+    }
+    if (document.getElementById('kernel-name') !== null) {
+        gKernel = document.getElementById('kernel-name').value;
+    }
+
+    gPlansTable = table({
+        tableId: 'plans-table',
+        tableLoadingDivId: 'table-loading',
+        tableDivId: 'table-div',
+    });
+
+    setTimeout(getBuilds, 10);
+
+    setTimeout(init.hotkeys, 50);
+    setTimeout(init.tooltip, 50);
+});

--- a/app/dashboard/static/js/app/view-new-api-job-branch-kernel.2022.11.js
+++ b/app/dashboard/static/js/app/view-new-api-job-branch-kernel.2022.11.js
@@ -229,6 +229,18 @@ require([
             return ttest.renderTestCount({data: data.id, type: type});
         }
 
+        /**
+         * Wrapper to provide the href.
+        **/
+        function _renderDetails(data, type, object) {
+            var href =
+                '/new-api-job/' + gJob +
+                '/branch/' + URI.encode(gBranch) +
+                '/kernel/' + gKernel +
+                '/plan/' + object.group + '/';
+            return ttest.renderDetails(href, type);
+        }
+
         if (results.length === 0) {
             html.replaceContent(
                 document.getElementById('table-div'),
@@ -266,6 +278,7 @@ require([
                     searchable: false,
                     orderable: false,
                     className: 'select-column pull-center',
+                    render: _renderDetails
                 }
             ];
             gPlansTable

--- a/app/dashboard/static/js/app/view-new-api-jobs-all.2022.11.js
+++ b/app/dashboard/static/js/app/view-new-api-jobs-all.2022.11.js
@@ -1,0 +1,166 @@
+/*!
+ * kernelci dashboard.
+ *
+ * Copyright (C) 2022 Collabora Limited
+ * Author: Alexandra Pereira <alexandra.pereira@collabora.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+require([
+    'jquery',
+    'utils/init',
+    'utils/error',
+    'utils/request',
+    'utils/table',
+    'utils/html',
+    'utils/const',
+    'tables/job',
+], function($, init, e, r, table, html, appconst, jobt) {
+    'use strict';
+    var gDateRange;
+    var gJobsTable;
+    var gPageLen;
+    var gSearchFilter;
+
+    setTimeout(function() {
+        document.getElementById('li-job').setAttribute('class', 'active');
+    }, 15);
+
+    gDateRange = appconst.MAX_DATE_RANGE;
+    gPageLen = null;
+    gSearchFilter = null;
+
+    function getJobsFail() {
+        html.replaceContent(
+            document.getElementById('table-loading'),
+            html.errorDiv('Error loading data.'));
+    }
+
+    function getJobsDone(response){
+        var columns;
+        var results;
+
+        function filterByDate(created){
+            var dateNow = new Date();
+            var dateReference = new Date(created);
+            dateNow.setDate(dateNow.getDate()-gDateRange);
+            return dateReference >= dateNow;
+        }
+
+        results = Object.values(response.items).filter(item => item.parent === null && filterByDate(item.created)).map((item) => {
+            var revision = item.revision;
+            revision.status = String(item.state).toUpperCase();
+            revision.created = item.created;
+            return revision
+        });
+
+        if (results.length === 0) {
+            html.removeElement(document.getElementById('table-loading'));
+            html.replaceContent(
+                document.getElementById('table-div'),
+                html.errorDiv('No jobs data available.'));
+        } else {
+            columns = [
+                {
+                    data: 'tree',
+                    title: 'Tree',
+                    type: 'string',
+                    className: 'tree-column'
+                },
+                {
+                    data: 'branch',
+                    title: 'Branch',
+                    type: 'string',
+                    className: 'branch-column'
+                },
+                {
+                    data: 'describe',
+                    title: 'Kernel',
+                    type: 'string',
+                    className: 'kernel-column'
+                },
+                {
+                    data: 'created',
+                    title: 'Date',
+                    type: 'date',
+                    className: 'pull-center',
+                    render: jobt.renderDate
+                },
+                {
+                    data: 'status',
+                    title: 'Status',
+                    type: 'string',
+                    className: 'pull-center',
+                    render: jobt.renderStatus
+                },
+                {
+                    data: 'tree',
+                    title: '',
+                    type: 'string',
+                    searchable: false,
+                    orderable: false,
+                    className: 'select-column pull-center'
+                }
+            ];
+
+            gJobsTable
+                .data(results)
+                .columns(columns)
+                .order([3, 'desc'])
+                .languageLengthMenu('jobs per page')
+                .draw();
+        }
+    }
+
+    function getJobs() {
+        var dateNow = new Date();
+        dateNow.setDate(dateNow.getDate()-gDateRange);
+        var data;
+        var deferred;
+
+        data = {
+            limit: 100000,
+            offset: 0,
+            created__gte: dateNow.toISOString().replace('Z', '000'),
+        };
+
+        deferred = r.get('/_ajax/nodes', data);
+        $.when(deferred)
+            .fail(e.error, getJobsFail)
+            .done(getJobsDone);
+    }
+
+    if (document.getElementById('search-filter') !== null) {
+        gSearchFilter = document.getElementById('search-filter').value;
+    }
+    if (document.getElementById('page-len') !== null) {
+        gPageLen = document.getElementById('page-len').value;
+    }
+    if (document.getElementById('date-range') !== null) {
+        gDateRange = document.getElementById('date-range').value;
+    }
+
+    gJobsTable = table({
+        tableId: 'jobstable',
+        tableDivId: 'table-div',
+        tableLoadingDivId: 'table-loading'
+    });
+
+    setTimeout(getJobs, 10);
+
+    setTimeout(init.hotkeys, 50);
+    setTimeout(init.tooltip, 50);
+});

--- a/app/dashboard/static/js/app/view-new-api-jobs-all.2022.11.js
+++ b/app/dashboard/static/js/app/view-new-api-jobs-all.2022.11.js
@@ -28,7 +28,8 @@ require([
     'utils/html',
     'utils/const',
     'tables/job',
-], function($, init, e, r, table, html, appconst, jobt) {
+    'URI',
+], function($, init, e, r, table, html, appconst, jobt, URI) {
     'use strict';
     var gDateRange;
     var gJobsTable;
@@ -52,6 +53,14 @@ require([
     function getJobsDone(response){
         var columns;
         var results;
+
+        function _renderDetails(data, type, object) {
+            var href =
+                '/new-api-job/' + data +
+                '/branch/' + URI.encode(object.branch) +
+                '/kernel/' + URI.encode(object.describe);
+            return jobt.renderDetails(href, type);
+        }
 
         function filterByDate(created){
             var dateNow = new Date();
@@ -112,7 +121,8 @@ require([
                     type: 'string',
                     searchable: false,
                     orderable: false,
-                    className: 'select-column pull-center'
+                    className: 'select-column pull-center',
+                    render: _renderDetails
                 }
             ];
 

--- a/app/dashboard/static/js/build.js
+++ b/app/dashboard/static/js/build.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (C) Collabora Limited 2020
+ * Copyright (C) Collabora Limited 2020, 2022
  * Author: Alexandra Pereira <alexandra.pereira@collabora.com>
  *
  * Copyright (C) Linaro Limited 2015,2016,2017,2019
@@ -71,6 +71,7 @@
             'app/view-jobs-all': 'app/view-jobs-all.2020.10',
             'app/view-jobs-job': 'app/view-jobs-job.2020.10',
             'app/view-jobs-job-branch': 'app/view-jobs-job-branch.2020.10',
+            'app/view-new-api-jobs-all': 'app/view-new-api-jobs-all.2022.11',
             'app/view-socs-all': 'app/view-socs-all.2020.10',
             'app/view-socs-soc': 'app/view-socs-soc.2020.10',
             'app/view-socs-soc-job': 'app/view-socs-soc-job.2020.10',
@@ -117,6 +118,7 @@
         {name: 'app/view-tests-case-id.2021.06'},
         {name: 'app/view-tests-job-branch-kernel.2020.10'},
         {name: 'app/view-tests-job-branch-kernel-plan.2020.10'},
+        {name: 'app/view-new-api-jobs-all.2022.11'},
         {name: 'kci-builds-all'},
         {name: 'kci-builds-id'},
         {name: 'kci-builds-job-kernel'},
@@ -136,5 +138,6 @@
         {name: 'kci-tests-job-branch-kernel'},
         {name: 'kci-tests-plan-id'},
         {name: 'kci-tests-case-id'},
+        {name: 'kci-new-api-jobs-all'},
     ]
 })

--- a/app/dashboard/static/js/build.js
+++ b/app/dashboard/static/js/build.js
@@ -72,6 +72,7 @@
             'app/view-jobs-job': 'app/view-jobs-job.2020.10',
             'app/view-jobs-job-branch': 'app/view-jobs-job-branch.2020.10',
             'app/view-new-api-jobs-all': 'app/view-new-api-jobs-all.2022.11',
+            'app/view-new-api-job-branch-kernel': 'app/view-new-api-job-branch-kernel.2022.11',
             'app/view-socs-all': 'app/view-socs-all.2020.10',
             'app/view-socs-soc': 'app/view-socs-soc.2020.10',
             'app/view-socs-soc-job': 'app/view-socs-soc-job.2020.10',
@@ -139,5 +140,6 @@
         {name: 'kci-tests-plan-id'},
         {name: 'kci-tests-case-id'},
         {name: 'kci-new-api-jobs-all'},
+        {name: 'kci-new-api-job-branch-kernel'},
     ]
 })

--- a/app/dashboard/static/js/build.js
+++ b/app/dashboard/static/js/build.js
@@ -73,6 +73,7 @@
             'app/view-jobs-job-branch': 'app/view-jobs-job-branch.2020.10',
             'app/view-new-api-jobs-all': 'app/view-new-api-jobs-all.2022.11',
             'app/view-new-api-job-branch-kernel': 'app/view-new-api-job-branch-kernel.2022.11',
+            'app/view-new-api-job-branch-kernel-plan': 'app/view-new-api-job-branch-kernel-plan.2022.11',
             'app/view-socs-all': 'app/view-socs-all.2020.10',
             'app/view-socs-soc': 'app/view-socs-soc.2020.10',
             'app/view-socs-soc-job': 'app/view-socs-soc-job.2020.10',
@@ -141,5 +142,6 @@
         {name: 'kci-tests-case-id'},
         {name: 'kci-new-api-jobs-all'},
         {name: 'kci-new-api-job-branch-kernel'},
+        {name: 'kci-new-api-job-branch-kernel-plan'}
     ]
 })

--- a/app/dashboard/static/js/common.js
+++ b/app/dashboard/static/js/common.js
@@ -68,6 +68,7 @@ require.config({
             'app/view-jobs-all': 'app/view-jobs-all.2020.10',
             'app/view-jobs-job': 'app/view-jobs-job.2020.10',
             'app/view-jobs-job-branch': 'app/view-jobs-job-branch.2020.10',
+            'app/view-new-api-jobs-all': 'app/view-new-api-jobs-all.2022.11',
             'app/view-socs-all': 'app/view-socs-all.2020.10',
             'app/view-socs-soc': 'app/view-socs-soc.2020.10',
             'app/view-socs-soc-job': 'app/view-socs-soc-job.2020.10',

--- a/app/dashboard/static/js/common.js
+++ b/app/dashboard/static/js/common.js
@@ -69,6 +69,7 @@ require.config({
             'app/view-jobs-job': 'app/view-jobs-job.2020.10',
             'app/view-jobs-job-branch': 'app/view-jobs-job-branch.2020.10',
             'app/view-new-api-jobs-all': 'app/view-new-api-jobs-all.2022.11',
+            'app/view-new-api-job-branch-kernel': 'app/view-new-api-job-branch-kernel.2022.11',
             'app/view-socs-all': 'app/view-socs-all.2020.10',
             'app/view-socs-soc': 'app/view-socs-soc.2020.10',
             'app/view-socs-soc-job': 'app/view-socs-soc-job.2020.10',

--- a/app/dashboard/static/js/common.js
+++ b/app/dashboard/static/js/common.js
@@ -70,6 +70,7 @@ require.config({
             'app/view-jobs-job-branch': 'app/view-jobs-job-branch.2020.10',
             'app/view-new-api-jobs-all': 'app/view-new-api-jobs-all.2022.11',
             'app/view-new-api-job-branch-kernel': 'app/view-new-api-job-branch-kernel.2022.11',
+            'app/view-new-api-job-branch-kernel-plan': 'app/view-new-api-job-branch-kernel-plan.2022.11',
             'app/view-socs-all': 'app/view-socs-all.2020.10',
             'app/view-socs-soc': 'app/view-socs-soc.2020.10',
             'app/view-socs-soc-job': 'app/view-socs-soc-job.2020.10',

--- a/app/dashboard/static/js/kci-new-api-job-branch-kernel-plan.js
+++ b/app/dashboard/static/js/kci-new-api-job-branch-kernel-plan.js
@@ -1,0 +1,23 @@
+/*!
+ * kernelci dashboard.
+ *
+ * Copyright (C) 2022  Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+require(['common'], function() {
+    'use strict';
+    require(['app/view-new-api-job-branch-kernel-plan']);
+});

--- a/app/dashboard/static/js/kci-new-api-job-branch-kernel.js
+++ b/app/dashboard/static/js/kci-new-api-job-branch-kernel.js
@@ -1,0 +1,23 @@
+/*!
+ * kernelci dashboard.
+ *
+ * Copyright (C) 2022  Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+require(['common'], function() {
+    'use strict';
+    require(['app/view-new-api-job-branch-kernel']);
+});

--- a/app/dashboard/static/js/kci-new-api-jobs-all.js
+++ b/app/dashboard/static/js/kci-new-api-jobs-all.js
@@ -1,0 +1,23 @@
+/*!
+ * kernelci dashboard.
+ *
+ * Copyright (C) 2022  Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+require(['common'], function() {
+    'use strict';
+    require(['app/view-new-api-jobs-all']);
+});

--- a/app/dashboard/templates/new-api-job-branch-kernel-plan.html
+++ b/app/dashboard/templates/new-api-job-branch-kernel-plan.html
@@ -1,0 +1,122 @@
+{%- extends "base.html" %}
+{%- block meta -%}
+    <meta name="csrf-token" content="{{ csrf_token_r() }}">
+{%- endblock %}
+{%- block title %}{{ page_title|safe }}{%- endblock %}
+{%- block head %}
+{{ super() }}
+<link rel="stylesheet" type="text/css" href="/static/css/dataTables.bootstrap-1.10.11.css">
+{%- endblock %}
+{%- block content %}
+<div class="row">
+    <div class="page-header">
+      <h3 id="body-title">
+        Results for <span id="plan-title">&hellip;</span>:
+        «<span id="kernel-title">&hellip;</span>»
+        <small>
+          (<span id="tree-title">&hellip;</span> /
+          <span id="branch-title">&hellip;</span>)
+        </small>
+      </h3>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+        <dl class="dl-horizontal">
+            <dt>Tree</dt>
+            <dd class="loading-content" id="tree">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Test Plan</dt>
+            <dd class="loading-content" id="plan">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git branch</dt>
+            <dd class="loading-content" id="git-branch">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git describe</dt>
+            <dd class="loading-content" id="git-describe">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git URL</dt>
+            <dd class="loading-content" id="git-url">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Date</dt>
+            <dd class="loading-content" id="job-date">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+        </dl>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+        <div id="pie-chart" class="chart-div pull-center">
+          <div id="pie-chart-heading">
+              <table id="pie-chart-legend" class="pie-chart">
+                  <tbody>
+                      <tr>
+                          <td id="show-pass" class="click-btn">0</td>
+                          <td>&nbsp;/&nbsp;</td>
+                          <td id="show-warning" class="click-btn">0</td>
+                          <td>&nbsp;/&nbsp;</td>
+                          <td id="show-fail" class="click-btn">0</td>
+                          <td>&nbsp;/&nbsp;</td>
+                          <td id="show-unknown" class="click-btn">0</td>
+                      </tr>
+                  </tbody>
+              </table>
+            </div>
+            <div id="test-chart"></div>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="page-header">
+            <h4>Test Results</h4>
+        </div>
+        <div class="row">
+            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+                <div class="btn-group btn-group-sm">
+                    <button id="btn-total" type="button" class="btn btn-default" disabled>All</button>
+                    <button id="btn-pass" type="button" class="btn btn-default" disabled>Successful</button>
+                    <button id="btn-regressions" type="button" class="btn btn-default" disabled>Regressions</button>
+                    <button id="btn-failures" type="button" class="btn btn-default" disabled>Failures</button>
+                    <button id="btn-unknown" type="button" class="btn btn-default" disabled>Unknown</button>
+                </div>
+            </div>
+        </div>
+        <div id="table-loading" class="pull-center">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
+                &nbsp;retrieving test data&hellip;
+            </small>
+        </div>
+    {%- if is_mobile %}
+        <div class="table-responsive" id="table-div">
+    {%- else %}
+        <div class="table" id="table-div">
+    {%- endif %}
+            <table class="table table-hover table-striped table-condensed clickable-table big-table" id="tests-table">
+            </table>
+        </div>
+    </div>
+</div>
+<input type="hidden" id="plan-name" value="{{ plan }}">
+<input type="hidden" id="job-name" value="{{ job }}">
+<input type="hidden" id="branch-name" value="{{ branch }}">
+<input type="hidden" id="kernel-name" value="{{ kernel }}">
+{%- endblock %}
+{%- block scripts %}
+<script data-main="/static/js/kci-new-api-job-branch-kernel-plan" src="/static/js/lib/require.js"></script>
+{%- endblock %}

--- a/app/dashboard/templates/new-api-job-branch-kernel.html
+++ b/app/dashboard/templates/new-api-job-branch-kernel.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+{%- block meta -%}
+<meta name="csrf-token" content="{{ csrf_token_r() }}">
+{%- endblock %}
+{%- block title %}{{ page_title|safe }}{%- endblock %}
+{%- block head %}
+{{ super() }}
+<style type="text/css">
+    .conflicts-table > thead {
+        font-weight: bold;
+    }
+    input[type="checkbox"] {
+        display: block;
+        margin: 0 auto;
+    }
+</style>
+<link rel="stylesheet" type="text/css" href="/static/css/dataTables.bootstrap-1.10.11.css">
+{%- endblock %}
+{%- block content %}
+<div class="row">
+    <div class="page-header">
+        <h3 id="details">{{ body_title|safe }}</h3>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7">
+        <dl class="dl-horizontal">
+            <dt>Tree</dt>
+            <dd class="loading-content" id="tree">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git branch</dt>
+            <dd class="loading-content" id="git-branch">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git describe</dt>
+            <dd class="loading-content" id="git-describe">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Git URL</dt>
+            <dd class="loading-content" id="git-url">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+            <dt>Date</dt>
+            <dd class="loading-content" id="job-date">
+                <small>
+                    <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>&nbsp;loading&hellip;
+                </small>
+            </dd>
+        </dl>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+        <div id="test-chart" class="chart-div pull-center"></div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="page-header">
+            <h3>Available Test Plans</h3>
+        </div>
+        <div id="table-loading" class="pull-center">
+            <small>
+                <i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
+                &nbsp;retrieving test data&hellip;
+            </small>
+        </div>
+    {%- if is_mobile %}
+        <div class="table-responsive" id="table-div">
+    {%- else %}
+        <div class="table" id="table-div">
+    {%- endif %}
+            <table class="table table-hover table-striped table-condensed clickable-table big-table" id="plans-table">
+            </table>
+        </div>
+    </div>
+</div>
+<input type="hidden" id="job-name" value="{{ job }}">
+<input type="hidden" id="branch-name" value="{{ branch }}">
+<input type="hidden" id="kernel-name" value="{{ kernel }}">
+{%- endblock %}
+{%- block scripts %}
+<script data-main="/static/js/kci-new-api-job-branch-kernel" src="/static/js/lib/require.js"></script>
+{%- endblock %}

--- a/app/dashboard/utils/route.py
+++ b/app/dashboard/utils/route.py
@@ -246,3 +246,8 @@ def init():
         methods=["GET"]
     )
 
+    add_rule(
+        "/new-api-job/<string:job>/branch/<path:branch>/kernel/<string:kernel>/plan/<string:plan>/",
+        view_func=vnewapi.APIJobBranchKernelPlanView.as_view("new-api-job-branch-kernel-plan"),
+        methods=["GET"]
+    )

--- a/app/dashboard/utils/route.py
+++ b/app/dashboard/utils/route.py
@@ -239,3 +239,10 @@ def init():
         view_func=vnewapi.APIJobsAllView.as_view("new-api-jobs"),
         methods=["GET"]
     )
+
+    add_rule(
+        "/new-api-job/<string:job>/branch/<path:branch>/kernel/<string:kernel>/",
+        view_func=vnewapi.APIJobBranchKernelView.as_view("new-api-job-branch-kernel"),
+        methods=["GET"]
+    )
+

--- a/app/dashboard/utils/route.py
+++ b/app/dashboard/utils/route.py
@@ -33,6 +33,7 @@ import dashboard.views.index as vindex
 import dashboard.views.job as vjob
 import dashboard.views.soc as vsoc
 import dashboard.views.test as vtest
+import dashboard.views.newapi as vnewapi
 
 import dashboard.utils.feed.job as jobfeed
 import dashboard.utils.feed.soc as socfeed
@@ -229,5 +230,12 @@ def init():
         ),
         view_func=vtest.TestJobBranchKernelPlanView.
         as_view("test-job-branch-kernel-plan"),
+        methods=["GET"]
+    )
+
+    #New API views
+    add_rule(
+        "/new-api-job/",
+        view_func=vnewapi.APIJobsAllView.as_view("new-api-jobs"),
         methods=["GET"]
     )

--- a/app/dashboard/views/newapi.py
+++ b/app/dashboard/views/newapi.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2022 Collabora LTD
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from flask import (
+    current_app as app,
+    render_template,
+    request
+)
+from flask.views import View
+
+from dashboard.utils.backend import get_search_parameters
+
+
+class GeneralNewAPIView(View):
+
+    PAGE_TITLE = app.config.get("DEFAULT_PAGE_TITLE")
+    JOB_PAGES_TITLE = "%s &mdash; %s" % (PAGE_TITLE, "Job Reports")
+    RSS_LINK = (
+        "<span class=\"rss-feed\">" +
+        "<a href=\"%s\" title=\"Recent Changes - Atom Feed\">" +
+        "<i class=\"fa fa-rss\"></i></a><span>"
+    )
+
+
+class APIJobsAllView(GeneralNewAPIView):
+    def dispatch_request(self):
+        body_title = "Available Jobs - New Kernel CI API"
+        search_filter, page_len = get_search_parameters(request)
+        return render_template(
+            "base-all.html",
+            table_id="jobstable",
+            data_main="kci-new-api-jobs-all",
+            body_title=body_title,
+            page_len=page_len,
+            page_title=self.JOB_PAGES_TITLE,
+            search_filter=search_filter
+        )

--- a/app/dashboard/views/newapi.py
+++ b/app/dashboard/views/newapi.py
@@ -69,3 +69,24 @@ class APIJobBranchKernelView(GeneralNewAPIView):
             kernel=kernel
         )
 
+
+class APIJobBranchKernelPlanView(GeneralNewAPIView):
+
+    def dispatch_request(self, **kwargs):
+        job, branch, kernel, plan = (kwargs[k] for k in ['job', 'branch', 'kernel', 'plan'])
+        page_title = "{} &mdash; {}/{} {}".format(
+            self.JOB_PAGES_TITLE, job, branch, kernel)
+        body_title = (
+            "Test Results: &#171;{}&#187 <small>({} / {})</small>".format(
+                kernel, job, branch)
+        )
+
+        return render_template(
+            "new-api-job-branch-kernel-plan.html",
+            page_title=page_title,
+            body_title=body_title,
+            job=job,
+            branch=branch,
+            kernel=kernel,
+            plan=plan
+        )

--- a/app/dashboard/views/newapi.py
+++ b/app/dashboard/views/newapi.py
@@ -47,3 +47,25 @@ class APIJobsAllView(GeneralNewAPIView):
             page_title=self.JOB_PAGES_TITLE,
             search_filter=search_filter
         )
+
+
+class APIJobBranchKernelView(GeneralNewAPIView):
+
+    def dispatch_request(self, **kwargs):
+        job, branch, kernel = (kwargs[k] for k in ['job', 'branch', 'kernel'])
+        page_title = "{} &mdash; {}/{} {}".format(
+            self.JOB_PAGES_TITLE, job, branch, kernel)
+        body_title = (
+            "Test Results: &#171;{}&#187 <small>({} / {})</small>".format(
+                kernel, job, branch)
+        )
+
+        return render_template(
+            "new-api-job-branch-kernel.html",
+            page_title=page_title,
+            body_title=body_title,
+            job=job,
+            branch=branch,
+            kernel=kernel
+        )
+


### PR DESCRIPTION
As we work on the new API for Kernel CI, we experiment with using it in the current dashboard.  The goals are twofold: test the state of the API to build a Web Dashboard and provide visualization of test runs with the new API in the current legacy dashboard; meanwhile, we don't have a new one.

Below you will see a description of the work and screens.

In the first page: ![page_1](https://user-images.githubusercontent.com/6344218/207398495-fd3211ca-9c65-4c13-81c8-cd808663c5b1.png)

You can see all job reports sent to the API, and using the pre-existent template, we bring data from the new API and show information about a job, restringing to tree, branch, kernel version, date and status. 

Once you select a row, combining kernel version, tree and branch, we will show, on the second page, which test plans we have for that given combined information: 
![page_2](https://user-images.githubusercontent.com/6344218/207398493-e41eda2a-8df1-4125-9ad2-ecc8429232c5.png)

Finally, in the third view, you can see all details of a given test plan combined with kernel version, date and branch.
Example page 3: ![page_3](https://user-images.githubusercontent.com/6344218/207398487-b535bf76-3bbd-40f8-899b-496fa9f30f95.png)
Example page 3.1: ![page_3 1](https://user-images.githubusercontent.com/6344218/207398491-0e7678f3-42f7-4938-add1-10d575714eac.png)
Example page 3.2: ![page_3 2](https://user-images.githubusercontent.com/6344218/207398489-2bf81169-e4dd-4326-a091-18b2f20faf83.png)

We already have some discussion around a new dashboard in progress (see [some user stories being discussed](https://github.com/kernelci/kernelci-project/discussions/28) ) the idea here is not to bring these views as the solution for this problem but a way to interact and gather information from the new API and experiment with it in a reasonable way to visualize data from new integrations as well (fstests, kunit). 

- New Kernel CI API is a work in progress, but we have been missing kernel revision information for over a week. I don't know if it is expected or even if it will be something permanent.

- Another thing, the API is not yet saving the logs in the DB. As we know, having the log information about the build is helpful in case of any problem or regression.

- It was tested locally, as shown in the screenshot above, using an API key and setting the `BACKEND_URL`  in the config file to the new API on staging. 